### PR TITLE
Cleaning up the code

### DIFF
--- a/src/libsyntax/diagnostics.rs
+++ b/src/libsyntax/diagnostics.rs
@@ -32,10 +32,10 @@ impl Span {
 /// Reporters are used to... report various errors, warnings, suggestions, threats, etc.
 /// which are encountered while processing the source code. SpanReporter reports such things
 /// in relation to some span of the source.
-pub trait SpanReporter<'a> {
+pub trait SpanReporter {
     /// Reports an error at given span with the given message.
-    fn error(&self, span: Span, message: &'a str);
+    fn error(&self, span: Span, message: &str);
 
     /// Reports an warning at given span with the given message.
-    fn warning(&self, span: Span, message: &'a str);
+    fn warning(&self, span: Span, message: &str);
 }

--- a/src/libsyntax/diagnostics.rs
+++ b/src/libsyntax/diagnostics.rs
@@ -10,7 +10,7 @@
 //! error and warning messages, notifications, etc.
 
 /// Span of a token.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Span {
     /// Byte offset of the first character of the span.
     pub from: usize,

--- a/src/libsyntax/lexer.rs
+++ b/src/libsyntax/lexer.rs
@@ -1769,8 +1769,6 @@ mod tests {
     use tokens::{Token};
     use diagnostics::{Span, SpanReporter};
 
-    // TODO: macros to lower the amount of boilerplate and arbitrary calculations
-
     #[test]
     fn empty_string() {
         check(&[], &[], &[]);

--- a/src/libsyntax/lexer.rs
+++ b/src/libsyntax/lexer.rs
@@ -19,6 +19,7 @@ use diagnostics::{Span, SpanReporter};
 //
 
 /// A scanned token with extents information.
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ScannedToken {
     /// The token itself.
     pub tok: Token,

--- a/src/libsyntax/tokens.rs
+++ b/src/libsyntax/tokens.rs
@@ -9,7 +9,7 @@
 //! This module contains definitions of various tokens recognized and processed by Sash parser.
 
 /// Types of tokens recognized by the scanner.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Token {
     /// Marker token denoting the end-of-token-stream condition.
     EOF,


### PR DESCRIPTION
This sands off some rough edges in the scanner and its tests. Also, after spending some time on trying to improve it I decided to drop some of the requirements stated in the tracking issue (#1):
- **Tracing.**
  It is not very needed now, given that tests::check() outputs the lists of tokens and error spans. More debug logs would be useful during  debugging, but such logs usually have ad-hoc nature and do not
  contribute any value to the 'production code'. That is, they are  usually removed and replaced with just more tests after the bug is  fixed.
- **Arbitrary calculations.**
  As I said in the last commit, I spent three days trying to implement  something simple, and it did not fly. I guess it would be faster to  just manually fixup the spans reported by check() than to bother  implementing, testing, and debugging the automated span constructor.
- **Verifying error message content.**
  I have found this to have little value for test coverage. There are  not many syntax errors which have exactly the same spans, so checking  the message content is redundant. Also, the users of the scanner do  not care about exact content so it is redundant to discriminate it.
