### PR TITLE
Improved token context

### DIFF
--- a/src/libsyntax/intern_pool.rs
+++ b/src/libsyntax/intern_pool.rs
@@ -1,0 +1,196 @@
+// Copyright (c) 2015, ilammy
+//
+// Licensed under MIT license (see LICENSE file in the root directory).
+// This file may be copied, distributed, and modified only in accordance
+// with the terms specified by this license.
+
+//! String inter pool.
+//!
+//! Interned strings (aka _atoms_ or _symbols_) provide an optimized way of handling lots of
+//! copies of equivalent strings which all have almost equivalent lifetime. This is a typical
+//! situation in a parser which has to deal with lots of strings (like identifier names and
+//! other tokens), pass them around, and compare them for equality.
+//!
+//! The strings are represented as integer indices (atoms) while their actual values are kept in
+//! the interner table. Thus string comparison is reduced to simpler integer comparison. Also,
+//! atoms may be freely copied around and do not have lifetimes associated with them so there
+//! is little syntactic and runtime overhead in handling interned strings.
+//!
+//! The only downside of this approach is that the atoms are not tied in any way to the interner
+//! which produced them. Thus it is possible to have dangling atoms, and to use a wrong interner
+//! to get the string value associated with the atom. However, this is not a problem in practice
+//! because usually there is only one intern pool in scope.
+
+use std::borrow;
+use std::cmp;
+use std::fmt;
+use std::ops;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+/// An interned string representation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
+pub struct Atom(u32);
+
+/// Value of an interned string.
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd)]
+pub struct InternedString {
+    /// Ref-counted pointer to the actual immutable data of this string.
+    data: Rc<String>,
+}
+
+impl InternedString {
+    /// Makes a fresh unique interned string value.
+    pub fn new(s: &str) -> InternedString {
+        InternedString {
+            data: Rc::new(s.to_string()),
+        }
+    }
+
+    /// Wraps an existing String into InternedString.
+    pub fn from_string(s: String) -> InternedString {
+        InternedString {
+            data: Rc::new(s),
+        }
+    }
+}
+
+impl cmp::Ord for InternedString {
+    fn cmp(&self, other: &InternedString) -> cmp::Ordering {
+        self[..].cmp(&other[..])
+    }
+}
+
+impl fmt::Debug for InternedString {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use std::fmt::Debug;
+        self[..].fmt(f)
+    }
+}
+
+impl fmt::Display for InternedString {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use std::fmt::Display;
+        self[..].fmt(f)
+    }
+}
+
+impl borrow::Borrow<str> for InternedString {
+    fn borrow(&self) -> &str {
+        &self.data[..]
+    }
+}
+
+impl ops::Deref for InternedString {
+    type Target = str;
+
+    fn deref(&self) -> &str { &self.data[..] }
+}
+
+/// A string intern pool.
+///
+/// This is the pool that keeps references to all interned strings and provides bidirectional
+/// lookup of strings by atoms and atoms by strings.
+pub struct InternPool {
+    /// A map keeping string -> atom associations, guaranteeing their uniqueness.
+    pool: RefCell<HashMap<InternedString, Atom>>,
+
+    /// A cache vector providing fast atom -> string lookup and generation of new atoms.
+    backrefs: RefCell<Vec<InternedString>>,
+}
+
+impl InternPool {
+    /// Creates a new empty string intern pool.
+    pub fn new() -> InternPool {
+        InternPool {
+            pool: RefCell::new(HashMap::new()),
+            backrefs: RefCell::new(Vec::new()),
+        }
+    }
+
+    /// Returns the atom corresponding to a given string. If the string is not yet in the pool
+    /// then it is interned and its brand new atom is returned.
+    pub fn intern(&self, s: &str) -> Atom {
+        if let Some(atom) = self.have_interned(s) {
+            return atom;
+        }
+        self.insert(InternedString::new(s))
+    }
+
+    /// Interns the given string into the pool and returns its atom. This method can be used to
+    /// avoid a string copy made by `intern()` if you can transfer ownership over a string.
+    pub fn intern_string(&self, s: String) -> Atom {
+        if let Some(atom) = self.have_interned(&s) {
+            return atom;
+        }
+        self.insert(InternedString::from_string(s))
+    }
+
+    /// Checks whether `s` has been already interned, returning the corresponding atom.
+    fn have_interned(&self, s: &str) -> Option<Atom> {
+        self.pool.borrow().get(s).cloned()
+    }
+
+    /// Inserts an interned string into the pool and returns corresponding atom.
+    fn insert(&self, interned: InternedString) -> Atom {
+        let mut pool = self.pool.borrow_mut();
+        let mut backrefs = self.backrefs.borrow_mut();
+
+        let new_atom = Atom(backrefs.len() as u32);
+
+        backrefs.push(interned.clone());
+        pool.insert(interned, new_atom);
+
+        return new_atom;
+    }
+
+    /// Retrieves the string value associated with a given atom.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the atom is not present in this pool.
+    pub fn get(&self, atom: Atom) -> InternedString {
+        let backrefs = self.backrefs.borrow();
+        return backrefs[atom.0 as usize].clone();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn intern_pool_sequential_atoms() {
+        let p = InternPool::new();
+
+        assert_eq!(p.intern("foo"),                         Atom(0));
+        assert_eq!(p.intern("bar"),                         Atom(1));
+        assert_eq!(p.intern_string("foo".to_string()),      Atom(0));
+        assert_eq!(p.intern_string("example".to_string()),  Atom(2));
+        assert_eq!(p.intern("bar"),                         Atom(1));
+        assert_eq!(p.intern_string("foo".to_string()),      Atom(0));
+    }
+
+    #[test]
+    fn intern_pool_getter() {
+        let p = InternPool::new();
+
+        let atom_123 = p.intern("123");
+        let atom_foo = p.intern("foo");
+        let atom_bar = p.intern("bar");
+        let atom_empty = p.intern("");
+
+        assert_eq!(&p.get(atom_123)[..], "123");
+        assert_eq!(&p.get(atom_foo)[..], "foo");
+        assert_eq!(&p.get(atom_bar)[..], "bar");
+        assert_eq!(&p.get(atom_empty)[..], "");
+    }
+
+    #[test]
+    #[should_panic]
+    fn intern_pool_invalid_atom() {
+        let p = InternPool::new();
+        p.get(Atom(9));
+    }
+}

--- a/src/libsyntax/lexer.rs
+++ b/src/libsyntax/lexer.rs
@@ -13,6 +13,7 @@ use std::char;
 
 use tokens::{Token, Delimiter, Lit};
 use diagnostics::{Span, SpanReporter};
+use intern_pool::{Atom, InternPool};
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // Helper data structures
@@ -54,6 +55,9 @@ pub trait Scanner {
 pub struct StringScanner<'a> {
     /// The string being scanned.
     buf: &'a str,
+
+    /// The intern pool for atoms stored in scanned tokens.
+    pool: &'a InternPool,
 
     // Scanning state
     //
@@ -107,10 +111,11 @@ impl<'a> Scanner for StringScanner<'a> {
 
 impl<'a> StringScanner<'a> {
     /// Makes a new scanner for the given string which will report scanning errors
-    /// to the given reporter.
-    pub fn new<'b>(s: &'b str, reporter: &'b SpanReporter) -> StringScanner<'b> {
+    /// to the given reporter and intern strings into the given pool.
+    pub fn new(s: &'a str, pool: &'a InternPool, reporter: &'a SpanReporter) -> StringScanner<'a> {
         let mut scanner = StringScanner {
             buf: s,
+            pool: pool,
             cur: None, pos: 0, prev_pos: 0,
             start: 0, end: 0,
             report: reporter,
@@ -164,6 +169,17 @@ impl<'a> StringScanner<'a> {
     /// Check whether next character (`peek()`) is `c`.
     fn peek_is(&self, c: char) -> bool {
         self.peek() == Some(c)
+    }
+
+    /// Interns a slice of `buf` into the intern pool.
+    fn intern_slice(&self, from: usize, to: usize) -> Atom {
+        let slice = &self.buf[from..to];
+        return self.pool.intern(slice);
+    }
+
+    /// Interns a given string into the intern pool.
+    fn intern_string(&self, str: String) -> Atom {
+        return self.pool.intern_string(str);
     }
 
     /// Extract the next token from the stream.
@@ -294,7 +310,9 @@ impl<'a> StringScanner<'a> {
             }
         }
 
-        return if doc_comment { Token::DocComment } else { Token::Comment };
+        return if doc_comment {
+            Token::DocComment(self.intern_slice(self.start, self.prev_pos))
+        } else { Token::Comment };
     }
 
     /// Scan a block comment.
@@ -350,7 +368,9 @@ impl<'a> StringScanner<'a> {
             return Token::Unrecognized;
         }
 
-        return if doc_comment { Token::DocComment } else { Token::Comment };
+        return if doc_comment {
+            Token::DocComment(self.intern_slice(self.start, self.prev_pos))
+        } else { Token::Comment };
     }
 
     /// Scan over any number literal.
@@ -399,7 +419,8 @@ impl<'a> StringScanner<'a> {
                 // Else it is just an integer followed by some dot. While dots can form identifiers
                 // (like '...'), type suffixes are defined as word-identifiers, which dots aren't.
                 // Thus we just go out with the suffixless integer we have already scanned over.
-                return Token::Literal(Lit::Integer);
+                let literal = self.intern_slice(self.start, self.prev_pos);
+                return Token::Literal(Lit::Integer(literal), None);
             }
         }
 
@@ -431,7 +452,9 @@ impl<'a> StringScanner<'a> {
             }
         }
 
-        self.scan_optional_type_suffix();
+        let literal = self.intern_slice(self.start, self.prev_pos);
+
+        let suffix = self.scan_optional_type_suffix();
 
         // Some late check for floating-point base. We do not support binary literals for floats.
         if !integer && (base != 10) {
@@ -439,7 +462,11 @@ impl<'a> StringScanner<'a> {
                 "only decimal base is supported for floating-point numbers");
         }
 
-        return Token::Literal(if integer { Lit::Integer } else { Lit::Float });
+        return Token::Literal(if integer {
+            Lit::Integer(literal)
+        } else {
+            Lit::Float(literal)
+        }, suffix);
     }
 
     /// Scan over a sequence of digits.
@@ -513,14 +540,14 @@ impl<'a> StringScanner<'a> {
         // A character literal is a single quote...
         self.expect_and_skip("\'");
 
-        let terminated = match self.scan_one_character_of_character() {
+        let value = match self.scan_one_character_of_character() {
             // ...followed by one character...
-            Ok(_) => {
+            Ok(c) => {
                 match self.scan_one_character_of_character() {
                     // ...and then by another single quote.
                     Err(SingleQuote) => {
                         self.read();
-                        true
+                        Some(c)
                     }
                     // If that's not a quote, pretend that we are scanning over a string, assuming
                     // that this is a one-line string mistakingly delimited by single quotes. But
@@ -549,9 +576,13 @@ impl<'a> StringScanner<'a> {
                                 }
                             }
                         }
-                        terminated
+                        if terminated {
+                            Some(REPLACEMENT_CHARACTER)
+                        } else {
+                            None
+                        }
                     }
-                    Err(UnexpectedTerminator) => { false }
+                    Err(UnexpectedTerminator) => { None }
                 }
             }
             // A literal single quote may be immediately followed by another literal single quote
@@ -560,25 +591,29 @@ impl<'a> StringScanner<'a> {
                 self.read();
                 if self.cur_is('\'') {
                     self.read();
+                    Some('\'')
                 } else {
                     self.report.error(Span::new(self.start, self.prev_pos),
                         "missing character in a character constant");
+                    Some(REPLACEMENT_CHARACTER)
                 }
-                true
             }
-            Err(UnexpectedTerminator) => { false }
+            Err(UnexpectedTerminator) => { None }
         };
 
-        if !terminated {
-            self.report.fatal(Span::new(self.start, self.prev_pos),
-                "unterminated character constant, expected a closing single quote (')");
+        match value {
+            Some(c) => {
+                let suffix = self.scan_optional_type_suffix();
 
-            return Token::Unrecognized;
+                return Token::Literal(Lit::Character(self.intern_string(c.to_string())), suffix);
+            }
+            None => {
+                self.report.fatal(Span::new(self.start, self.prev_pos),
+                    "unterminated character constant, expected a closing single quote (')");
+
+                return Token::Unrecognized;
+            }
         }
-
-        self.scan_optional_type_suffix();
-
-        return Token::Literal(Lit::Character);
     }
 
     /// Scan over a string literal.
@@ -588,11 +623,13 @@ impl<'a> StringScanner<'a> {
         // Strings start with a double quote...
         self.expect_and_skip("\"");
 
+        let mut value = String::new();
+
         loop {
             match self.scan_one_character_of_string() {
                 // ...then it contains some characters...
-                Ok(_) => {
-                    // (which we currently ignore)
+                Ok(c) => {
+                    value.push(c);
                 }
                 // ...or escaped line endings, which are ignored...
                 Err(SkippedEscapedLineEnding) => { }
@@ -612,9 +649,9 @@ impl<'a> StringScanner<'a> {
             }
         }
 
-        self.scan_optional_type_suffix();
+        let suffix = self.scan_optional_type_suffix();
 
-        return Token::Literal(Lit::String);
+        return Token::Literal(Lit::String(self.intern_string(value)), suffix);
     }
 
     /// Scan over an explicit symbol.
@@ -624,11 +661,13 @@ impl<'a> StringScanner<'a> {
         // Symbols start with a backquote...
         self.expect_and_skip("`");
 
+        let mut value = String::new();
+
         loop {
             match self.scan_one_character_of_symbol() {
                 // ...then we have some characters...
-                Ok(_) => {
-                    // (which we currently ignore)
+                Ok(c) => {
+                    value.push(c);
                 }
                 // ...and finally the symbol ends with a closing backquote.
                 Err(Backquote) => {
@@ -645,7 +684,7 @@ impl<'a> StringScanner<'a> {
             }
         }
 
-        return Token::ExplicitSymbol;
+        return Token::ExplicitSymbol(self.intern_string(value));
     }
 
     /// Scan over a single character or escape sequence for a character literal.
@@ -1085,15 +1124,15 @@ impl<'a> StringScanner<'a> {
         if digits != 2 {
             self.report.error(Span::new(escape_start, digits_end),
                 "expected exactly two hexadecimal digits in a byte escape (e.g., \\x3A)");
-        } else {
-            if value > 0x7F {
-                self.report.error(Span::new(escape_start, digits_end),
-                    "byte escapes can only encode ASCII characters (\\x00..\\x7F)");
-            }
+            return REPLACEMENT_CHARACTER;
         }
 
-        // The value may be incorrect, but this method is used only in character and string
-        // contexts where we do not really care about this (from the lexical standpoint)
+        if value > 0x7F {
+            self.report.error(Span::new(escape_start, digits_end),
+                "byte escapes can only encode ASCII characters (\\x00..\\x7F)");
+            return REPLACEMENT_CHARACTER;
+        }
+
         return value as char;
     }
 
@@ -1284,17 +1323,29 @@ impl<'a> StringScanner<'a> {
         // Raw string content starts with an double quote
         self.expect_and_skip("\"");
 
+        let mut value = String::new();
+
         loop {
             match self.cur {
                 Some('"') => {
-                    if self.scan_raw_string_trailers(hash_count) {
-                        break;
+                    match self.scan_raw_string_trailers(hash_count) {
+                        Some(chunk) => {
+                            value.push_str(chunk);
+                        }
+                        None => {
+                            break;
+                        }
                     }
                 }
                 Some(c) => {
-                    if c == '\r' && self.peek() != Some('\n') {
-                        self.report.error(Span::new(self.prev_pos, self.pos),
-                            "bare CR is not allowed in raw strings, use \\r instead");
+                    if c == '\r' {
+                        if self.peek() != Some('\n') {
+                            self.report.error(Span::new(self.prev_pos, self.pos),
+                                "bare CR is not allowed in raw strings, use \\r instead");
+                            value.push('\r');
+                        }
+                    } else {
+                        value.push(c);
                     }
                     self.read();
                 }
@@ -1313,9 +1364,9 @@ impl<'a> StringScanner<'a> {
             }
         }
 
-        self.scan_optional_type_suffix();
+        let suffix = self.scan_optional_type_suffix();
 
-        return Token::Literal(Lit::RawString);
+        return Token::Literal(Lit::RawString(self.intern_string(value)), suffix);
     }
 
     /// Scan over raw string trailing sequence `"#...#`.
@@ -1323,11 +1374,12 @@ impl<'a> StringScanner<'a> {
     /// Scanner stops either at the first non-`#` character, or at the end of file, or when
     /// `hash_count` hashes have been scanned over, whichever comes first.
     ///
-    /// Returns `true` when a correct trailing sequence was scanned, and `false` if there
-    /// were not enough hashes after the quote and the raw string content possibly goes on.
-    /// (Possibly, because `false` is also returned when EOF is reached before the sufficient
-    /// number of hashes are scanner over.)
-    fn scan_raw_string_trailers(&mut self, hash_count: u32) -> bool {
+    /// Returns None when a correct trailing sequence was scanned, or Some slice of text if there
+    /// were not enough hashes after the quote and the raw string content possibly goes on. The
+    /// slice contains the part of buffer that has been scanned over.
+    fn scan_raw_string_trailers(&mut self, hash_count: u32) -> Option<&str> {
+        let chunk_start = self.prev_pos;
+
         // Raw string content ends with an double quote
         self.expect_and_skip("\"");
 
@@ -1338,11 +1390,13 @@ impl<'a> StringScanner<'a> {
                 seen += 1;
                 self.read();
             } else {
-                return false;
+                let chunk_end = self.prev_pos;
+
+                return Some(&self.buf[chunk_start..chunk_end]);
             }
         }
 
-        return true;
+        return None;
     }
 
     /// Scan over an identifier or maybe an implicit symbol.
@@ -1431,6 +1485,9 @@ impl<'a> StringScanner<'a> {
         // Word identifiers must start with a proper starter
         assert!(sash_identifiers::category_of(initial).is(WORD_START));
 
+        let mut value = String::new();
+        value.push(initial);
+
         loop {
             let old_prev_pos = self.prev_pos;
             match self.scan_one_character_of_identifier() {
@@ -1440,6 +1497,7 @@ impl<'a> StringScanner<'a> {
 
                     // Just go on scanning thw word if this a valid continuation
                     if category.is(WORD_CONTINUE) {
+                        value.push(c);
                         continue;
                     }
 
@@ -1452,6 +1510,7 @@ impl<'a> StringScanner<'a> {
 
                     // If this does not seem to be a valid continuation character, just report it,
                     // greedily eat it, and go on scanning, pretending that this was an accident.
+                    value.push(c);
                     self.report.error(Span::new(old_prev_pos, self.prev_pos),
                         format!("this character not allowed in word identifiers: \
                                  '{}' (U+{:04X})", c, c as u32).as_ref());
@@ -1459,15 +1518,20 @@ impl<'a> StringScanner<'a> {
                 // The same is true for invalid Unicode escapes, just carry on scanning.
                 // Don't report the error, the user already knows about malformed Unicode
                 // which is obviously incorrect identifier character
-                Err(IncorrectUnicodeEscape) => { }
+                Err(IncorrectUnicodeEscape) => {
+                    value.push(REPLACEMENT_CHARACTER);
+                }
                 // For ASCII escapes it's also true, but we need a message
                 Err(AsciiUnicodeEscape) => {
+                    value.push(REPLACEMENT_CHARACTER);
                     self.report.error(Span::new(old_prev_pos, self.prev_pos),
                         "escaped ASCII is not allowed in identifiers");
                 }
                 // Decimal digits are valid contiuations of word identifiers
                 Err(Digit) => {
-                    assert!(sash_identifiers::category_of(self.cur.unwrap()).is(WORD_CONTINUE));
+                    let c = self.cur.unwrap();
+                    assert!(sash_identifiers::category_of(c).is(WORD_CONTINUE));
+                    value.push(c);
                     self.read();
                     continue;
                 }
@@ -1479,7 +1543,7 @@ impl<'a> StringScanner<'a> {
             }
         }
 
-        return Token::Identifier;
+        return Token::Identifier(self.intern_string(value));
     }
 
     /// Scan over a standalone word identifier or maybe an implicit symbol which starts
@@ -1490,7 +1554,10 @@ impl<'a> StringScanner<'a> {
         // Word identifier followed by a single colon forms an implicit symbol token.
         if (self.cur_is(':')) && (self.peek() != Some(':')) {
             self.read();
-            return Token::ImplicitSymbol;
+            return match initial_token {
+                Token::Identifier(atom) => Token::ImplicitSymbol(atom),
+                _ => unreachable!()
+            }
         }
 
         return initial_token;
@@ -1506,6 +1573,15 @@ impl<'a> StringScanner<'a> {
         // Mark identifiers must start with a proper starter
         assert!(sash_identifiers::category_of(initial).is(MARK_START));
 
+        let mut value = String::new();
+
+        // The initial dot is not scanned over by scan_identifier_or_symbol() in order to allow
+        // the loop below to make use of scan_one_character_of_identifier(). Do not add the dot
+        // into the representation string right now, it will be correctly added afterwards.
+        if initial != '.' {
+            value.push(initial);
+        }
+
         loop {
             let old_prev_pos = self.prev_pos;
             match self.scan_one_character_of_identifier() {
@@ -1515,6 +1591,7 @@ impl<'a> StringScanner<'a> {
 
                     // Just go on scanning thw word if this a valid continuation
                     if category.is(MARK_CONTINUE) {
+                        value.push(c);
                         continue;
                     }
 
@@ -1527,6 +1604,7 @@ impl<'a> StringScanner<'a> {
 
                     // If this does not seem to be a valid continuation character, just report it,
                     // greedily eat it, and go on scanning, pretending that this was an accident.
+                    value.push(c);
                     self.report.error(Span::new(old_prev_pos, self.prev_pos),
                         format!("this character not allowed in mark identifiers: \
                                  '{}' (U+{:04X})", c, c as u32).as_ref());
@@ -1534,9 +1612,12 @@ impl<'a> StringScanner<'a> {
                 // The same is true for invalid Unicode escapes, just carry on scanning.
                 // Don't report the error, the user already knows about malformed Unicode
                 // which is obviously incorrect identifier character
-                Err(IncorrectUnicodeEscape) => { }
+                Err(IncorrectUnicodeEscape) => {
+                    value.push(REPLACEMENT_CHARACTER);
+                }
                 // For ASCII escapes it's also true, but we need a message
                 Err(AsciiUnicodeEscape) => {
+                    value.push(REPLACEMENT_CHARACTER);
                     self.report.error(Span::new(old_prev_pos, self.prev_pos),
                         "escaped ASCII is not allowed in identifiers");
                 }
@@ -1546,6 +1627,7 @@ impl<'a> StringScanner<'a> {
                 Err(Dot) => {
                     if self.peek_is('.') {
                         while self.cur_is('.') {
+                            value.push('.');
                             self.read();
                         }
                     } else {
@@ -1560,7 +1642,7 @@ impl<'a> StringScanner<'a> {
             }
         }
 
-        return Token::Identifier;
+        return Token::Identifier(self.intern_string(value));
     }
 
     /// Scan over a quote identifier which starts with `initial` character.
@@ -1572,6 +1654,9 @@ impl<'a> StringScanner<'a> {
 
         // Quote identifiers must start with a proper starter
         assert!(sash_identifiers::category_of(initial).is(QUOTE_START));
+
+        let mut value = String::new();
+        value.push(initial);
 
         loop {
             let old_prev_pos = self.prev_pos;
@@ -1600,13 +1685,17 @@ impl<'a> StringScanner<'a> {
                             format!("this character not allowed in quote identifiers: \
                                  '{}' (U+{:04X})", c, c as u32).as_ref());
                     }
+                    value.push(c);
                 }
                 // The same is true for invalid Unicode escapes, just carry on scanning.
                 // Don't report the error, the user already knows about malformed Unicode
                 // which is obviously incorrect identifier character
-                Err(IncorrectUnicodeEscape) => { }
+                Err(IncorrectUnicodeEscape) => {
+                    value.push(REPLACEMENT_CHARACTER);
+                }
                 // For ASCII escapes it's also true, but we need a message
                 Err(AsciiUnicodeEscape) => {
+                    value.push(REPLACEMENT_CHARACTER);
                     self.report.error(Span::new(old_prev_pos, self.prev_pos),
                         "escaped ASCII is not allowed in identifiers");
                 }
@@ -1618,11 +1707,11 @@ impl<'a> StringScanner<'a> {
             }
         }
 
-        return Token::Identifier;
+        return Token::Identifier(self.intern_string(value));
     }
 
     /// Maybe scan over an optional type suffix of literal tokens.
-    fn scan_optional_type_suffix(&mut self) {
+    fn scan_optional_type_suffix(&mut self) -> Option<Atom> {
         use unicode::sash_identifiers;
         use unicode::sash_identifiers::{WORD_START, MARK_START, QUOTE_START,
             WORD_CONTINUE, MARK_CONTINUE, QUOTE_CONTINUE};
@@ -1642,10 +1731,13 @@ impl<'a> StringScanner<'a> {
                 let category = sash_identifiers::category_of(c);
 
                 if category.is(WORD_START) {
-                    self.scan_identifier_word(c);
-                } else {
-                    self.unread(c, old_prev_pos);
+                    return match self.scan_identifier_word(c) {
+                        Token::Identifier(atom) => Some(atom),
+                        _ => unreachable!(),
+                    };
                 }
+
+                self.unread(c, old_prev_pos);
             }
             // Some incorrect escape sequence has been scanned over. This is certainly not going
             // to be a word, so we should put the character back. But we do not know the specific
@@ -1666,6 +1758,8 @@ impl<'a> StringScanner<'a> {
             // Just go out, there is nothing interesting for us here.
             Err(Dot) | Err(Terminator) | Err(Digit) => { }
         }
+
+        return None;
     }
 }
 
@@ -1778,17 +1872,53 @@ mod tests {
     use tokens::{Token, Delimiter, Lit};
     use diagnostics;
     use diagnostics::{Span, SpanReporter, Severity};
+    use intern_pool::{Atom, InternPool};
+
+    macro_rules! check {
+        { $( ( $($spec:tt)* ) ),* ; $( $severity:path : $( ($from:expr, $to:expr) ),+ ; )* } => {{
+            let pool = InternPool::new();
+            let slices = &[
+                $( slice!(pool, $($spec)*) , )*
+            ];
+            let diagnostics = &[
+                $( $( ($severity, Span::new($from, $to)), )+ )*
+            ];
+            check(slices, diagnostics, pool);
+        }}
+    }
+
+    macro_rules! slice {
+        { $pool:expr, $str:expr => $tok:ident } => {
+            ScannerTestSlice($str, Token::$tok)
+        };
+        { $pool:expr, $str:expr => OpenDelim($delim:ident) } => {
+            ScannerTestSlice($str, Token::OpenDelim(Delimiter::$delim))
+        };
+        { $pool:expr, $str:expr => CloseDelim($delim:ident) } => {
+            ScannerTestSlice($str, Token::CloseDelim(Delimiter::$delim))
+        };
+        { $pool:expr, $str:expr => Literal($lit:ident, $val:expr) } => {
+            ScannerTestSlice($str, Token::Literal(Lit::$lit($pool.intern($val)), None))
+        };
+        { $pool:expr, $str:expr => Literal($lit:ident, $val:expr, $suffix:expr) } => {
+            ScannerTestSlice($str, Token::Literal(Lit::$lit($pool.intern($val)),
+                                                  Some($pool.intern($suffix))))
+        };
+        { $pool:expr, $str:expr => $tok:ident($val:expr) } => {
+            ScannerTestSlice($str, Token::$tok($pool.intern($val)))
+        };
+    }
 
     #[test]
     fn empty_string() {
-        check(&[], &[], &[]);
+        check! { ; }
     }
 
     #[test]
     fn whitespace() {
-        check(&[
-            ScannerTestSlice("   \t\t\r\n  \t \t\n", Token::Whitespace),
-        ], &[], &[]);
+        check! {
+            ("   \t\t\r\n  \t \t\n"     => Whitespace);
+        }
     }
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1796,52 +1926,58 @@ mod tests {
 
     #[test]
     fn line_comment_lf() {
-        check(&[
-            ScannerTestSlice("// example line comment",     Token::Comment),
-            ScannerTestSlice("\n       \t",                 Token::Whitespace),
-        ], &[], &[]);
+        check! {
+            ("// example line comment"  => Comment),
+            ("\n       \t"              => Whitespace);
+        }
     }
 
     #[test]
     fn line_comment_crlf() {
-        check(&[
-            ScannerTestSlice("// example line comment",     Token::Comment),
-            ScannerTestSlice("\r\n       \t",               Token::Whitespace),
-        ], &[], &[]);
+        check! {
+            ("// example line comment"  => Comment),
+            ("\r\n       \t"            => Whitespace);
+        }
     }
 
     #[test]
     fn line_comment_cr() {
-        check(&[
-            ScannerTestSlice("// example line comment\r       \t", Token::Comment),
-        ], &[Span::new(23, 24)], &[]);
+        check! {
+            ("// example line comment\r       \t" => Comment);
+
+        Severity::Error:
+            (23, 24);
+        }
     }
 
     #[test]
     fn line_comment_consecutive_lf() {
-        check(&[
-            ScannerTestSlice("// line 1",       Token::Comment),
-            ScannerTestSlice("\n",              Token::Whitespace),
-            ScannerTestSlice("// line 2",       Token::Comment),
-            ScannerTestSlice("\n     ",         Token::Whitespace),
-        ], &[], &[]);
+        check! {
+            ("// line 1" => Comment),
+            ("\n"        => Whitespace),
+            ("// line 2" => Comment),
+            ("\n     "   => Whitespace);
+        }
     }
 
     #[test]
     fn line_comment_consecutive_crlf() {
-        check(&[
-            ScannerTestSlice("// line 1",       Token::Comment),
-            ScannerTestSlice("\r\n",            Token::Whitespace),
-            ScannerTestSlice("// line 2",       Token::Comment),
-            ScannerTestSlice("\r\n     ",       Token::Whitespace),
-        ], &[], &[]);
+        check! {
+            ("// line 1" => Comment),
+            ("\r\n"      => Whitespace),
+            ("// line 2" => Comment),
+            ("\r\n     " => Whitespace);
+        }
     }
 
     #[test]
     fn line_comment_consecutive_cr() {
-        check(&[
-            ScannerTestSlice("// line 1\r// line 2\r     ", Token::Comment),
-        ], &[Span::new(9, 10), Span::new(19, 20)], &[]);
+        check! {
+            ("// line 1\r// line 2\r     " => Comment);
+
+        Severity::Error:
+            (9, 10), (19, 20);
+        }
     }
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1849,60 +1985,69 @@ mod tests {
 
     #[test]
     fn block_comment_simple() {
-        check(&[
-            ScannerTestSlice("/* example */", Token::Comment),
-        ], &[], &[]);
+        check! {
+            ("/* example */" => Comment);
+        }
     }
 
     #[test]
     fn block_comment_multiline() {
-        check(&[
-            ScannerTestSlice("/* example\non the next line */", Token::Comment),
-        ], &[], &[]);
+        check! {
+            ("/* example\non the next line */" => Comment);
+        }
     }
 
     #[test]
     fn block_comment_nested() {
-        check(&[
-            ScannerTestSlice("/* /* nested */ example /**/*/", Token::Comment),
-        ], &[], &[]);
+        check! {
+            ("/* /* nested */ example /**/*/" => Comment);
+        }
     }
 
     #[test]
     fn block_comment_consecutive() {
-        check(&[
-            ScannerTestSlice("/*1*/", Token::Comment),
-            ScannerTestSlice("\n",    Token::Whitespace),
-            ScannerTestSlice("/*2*/", Token::Comment),
-        ], &[], &[]);
+        check! {
+            ("/*1*/" => Comment),
+            ("\n"    => Whitespace),
+            ("/*2*/" => Comment);
+        }
     }
 
     #[test]
     fn block_comment_unterminated_1() {
-        check(&[
-            ScannerTestSlice("/* forgot", Token::Unrecognized),
-        ], &[], &[Span::new(0, 9)]);
+        check! {
+            ("/* forgot" => Unrecognized);
+
+        Severity::Fatal:
+            (0, 9);
+        }
     }
 
     #[test]
     fn block_comment_unterminated_2() {
-        check(&[
-            ScannerTestSlice("/*/", Token::Unrecognized),
-        ], &[], &[Span::new(0, 3)]);
+        check! {
+            ("/*/" => Unrecognized);
+
+        Severity::Fatal:
+            (0, 3);
+        }
     }
 
     #[test]
     fn block_comment_unterminated_nested() {
-        check(&[
-            ScannerTestSlice("/*/*nested*/", Token::Unrecognized),
-        ], &[], &[Span::new(0, 12)]);
+        check! {
+            ("/*/*nested*/" => Unrecognized);
+
+        Severity::Fatal:
+            (0, 12);
+        }
     }
 
     #[test]
     fn block_comment_line_comment_allows_unterminated_blocks() {
-        check(&[
-            ScannerTestSlice("// /* doesn't matter", Token::Comment),
-        ], &[], &[]);
+        check! {
+            ("// /* doesn't matter" => Comment);
+        }
     }
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1910,119 +2055,120 @@ mod tests {
 
     #[test]
     fn doc_comment_line() {
-        check(&[
-            ScannerTestSlice("/// Example",                                     Token::DocComment),
-            ScannerTestSlice("\n",                                              Token::Whitespace),
-            ScannerTestSlice("/// Other line",                                  Token::DocComment),
-            ScannerTestSlice("\r\n",                                            Token::Whitespace),
-            ScannerTestSlice("/// More",                                        Token::DocComment),
-            ScannerTestSlice("\n\n",                                            Token::Whitespace),
-            ScannerTestSlice("//! Inner comments",                              Token::DocComment),
-            ScannerTestSlice("\n",                                              Token::Whitespace),
-            ScannerTestSlice("//! Windows lines",                               Token::DocComment),
-            ScannerTestSlice("\r\n\r\n",                                        Token::Whitespace),
-            ScannerTestSlice("/// Mixed",                                       Token::DocComment),
-            ScannerTestSlice("\n",                                              Token::Whitespace),
-            ScannerTestSlice("//! Mixed",                                       Token::DocComment),
-            ScannerTestSlice("\r\n",                                            Token::Whitespace),
-        ], &[], &[]);
+        check! {
+            ("/// Example"                                      => DocComment("/// Example")),
+            ("\n"                                               => Whitespace),
+            ("/// Other line"                                   => DocComment("/// Other line")),
+            ("\r\n"                                             => Whitespace),
+            ("/// More"                                         => DocComment("/// More")),
+            ("\n\n"                                             => Whitespace),
+            ("//! Inner comments"                               => DocComment("//! Inner comments")),
+            ("\n"                                               => Whitespace),
+            ("//! Windows lines"                                => DocComment("//! Windows lines")),
+            ("\r\n\r\n"                                         => Whitespace),
+            ("/// Mixed"                                        => DocComment("/// Mixed")),
+            ("\n"                                               => Whitespace),
+            ("//! Mixed"                                        => DocComment("//! Mixed")),
+            ("\r\n"                                             => Whitespace);
+        }
     }
 
     #[test]
     fn doc_comment_block() {
-        check(&[
-            ScannerTestSlice("/** Example */",                                  Token::DocComment),
-            ScannerTestSlice("\n",                                              Token::Whitespace),
-            ScannerTestSlice("/** Multiple\n    lines\r\n    are allowed */",   Token::DocComment),
-            ScannerTestSlice("\n",                                              Token::Whitespace),
-            ScannerTestSlice("/*! Some more\n    inner\r\n comments !*/",       Token::DocComment),
-            ScannerTestSlice("\r\n",                                            Token::Whitespace),
-            ScannerTestSlice("/*! and /*! they /** can */ be ****/ nested */",  Token::DocComment),
-            ScannerTestSlice("/** in /*!! any */ way /* you */ like */",        Token::DocComment),
-        ], &[], &[]);
+        check! {
+            ("/** Example */"                                   => DocComment("/** Example */")),
+            ("\n"                                               => Whitespace),
+            ("/** Multiple\n    lines\r\n    are allowed */"    => DocComment("/** Multiple\n    lines\r\n    are allowed */")),
+            ("\n"                                               => Whitespace),
+            ("/*! Some more\n    inner\r\n comments !*/"        => DocComment("/*! Some more\n    inner\r\n comments !*/")),
+            ("\r\n"                                             => Whitespace),
+            ("/*! and /*! they /** can */ be ****/ nested */"   => DocComment("/*! and /*! they /** can */ be ****/ nested */")),
+            ("/** in /*!! any */ way /* you */ like */"         => DocComment("/** in /*!! any */ way /* you */ like */"));
+        }
     }
 
     #[test]
     fn doc_comment_intertype_nesting() {
-        check(&[
-            ScannerTestSlice("/// This /* is fine */",                          Token::DocComment),
-            ScannerTestSlice("\n",                                              Token::Whitespace),
-            ScannerTestSlice("//! This /*! is too",                             Token::DocComment),
-            ScannerTestSlice("\r\n\n",                                          Token::Whitespace),
-            ScannerTestSlice("/** Also // fine */",                             Token::DocComment),
-            ScannerTestSlice("\n",                                              Token::Whitespace),
-            ScannerTestSlice("/*! Fine as well // */",                          Token::DocComment),
-            ScannerTestSlice("\r\n",                                            Token::Whitespace),
-            ScannerTestSlice("// /// These are also",                           Token::Comment),
-            ScannerTestSlice("\n",                                              Token::Whitespace),
-            ScannerTestSlice("/* /** // fine */ */",                            Token::Comment),
-        ], &[], &[]);
+        check! {
+            ("/// This /* is fine */"                           => DocComment("/// This /* is fine */")),
+            ("\n"                                               => Whitespace),
+            ("//! This /*! is too"                              => DocComment("//! This /*! is too")),
+            ("\r\n\n"                                           => Whitespace),
+            ("/** Also // fine */"                              => DocComment("/** Also // fine */")),
+            ("\n"                                               => Whitespace),
+            ("/*! Fine as well // */"                           => DocComment("/*! Fine as well // */")),
+            ("\r\n"                                             => Whitespace),
+            ("// /// These are also"                            => Comment),
+            ("\n"                                               => Whitespace),
+            ("/* /** // fine */ */"                             => Comment);
+        }
     }
 
     #[test]
     fn doc_comment_block_unterminated() {
-        check(&[ScannerTestSlice("/** forgot ", Token::Unrecognized)], &[], &[Span::new(0, 11)]);
-        check(&[ScannerTestSlice("/*! as well", Token::Unrecognized)], &[], &[Span::new(0, 11)]);
-        check(&[ScannerTestSlice("/** /*nest",  Token::Unrecognized)], &[], &[Span::new(0, 10)]);
-        check(&[ScannerTestSlice("/*!/*!*/",    Token::Unrecognized)], &[], &[Span::new(0,  8)]);
+        check! { ("/** forgot " => Unrecognized); Severity::Fatal: (0, 11); }
+        check! { ("/*! as well" => Unrecognized); Severity::Fatal: (0, 11); }
+        check! { ("/** /*nest"  => Unrecognized); Severity::Fatal: (0, 10); }
+        check! { ("/*!/*!*/"    => Unrecognized); Severity::Fatal: (0,  8); }
     }
 
     #[test]
     fn doc_comment_bare_crs() {
-        check(&[
-            ScannerTestSlice("/// bare crs\r///are errors",                     Token::DocComment),
-            ScannerTestSlice("\n",                                              Token::Whitespace),
-            ScannerTestSlice("//! in all\r\r\rkinds of doc-comments",           Token::DocComment),
-            ScannerTestSlice("\n\n",                                            Token::Whitespace),
-            ScannerTestSlice("/** and I mean \r all */",                        Token::DocComment),
-            ScannerTestSlice("\r\n",                                            Token::Whitespace),
-            ScannerTestSlice("/*! like /* \r this */ */",                       Token::DocComment),
-        ], &[ Span::new( 12,  13), Span::new( 37,  38), Span::new( 38,  39), Span::new( 39,  40),
-              Span::new( 78,  79), Span::new(100, 101),
-        ], &[]);
+        check! {
+            ("/// bare crs\r///are errors"                      => DocComment("/// bare crs\r///are errors")),
+            ("\n"                                               => Whitespace),
+            ("//! in all\r\r\rkinds of doc-comments"            => DocComment("//! in all\r\r\rkinds of doc-comments")),
+            ("\n\n"                                             => Whitespace),
+            ("/** and I mean \r all */"                         => DocComment("/** and I mean \r all */")),
+            ("\r\n"                                             => Whitespace),
+            ("/*! like /* \r this */ */"                        => DocComment("/*! like /* \r this */ */"));
+
+        Severity::Error:
+            (12, 13), (37, 38), (38, 39), (39, 40), (78, 79), (100, 101);
+        }
     }
 
     #[test]
     fn doc_comment_non_docs() {
-        check(&[
-            ScannerTestSlice("/////////////////////////////////",               Token::Comment),
-            ScannerTestSlice("\n",                                              Token::Whitespace),
-            ScannerTestSlice("// These are not doc comments",                   Token::Comment),
-            ScannerTestSlice("\n",                                              Token::Whitespace),
-            ScannerTestSlice("/////////////////////////////////",               Token::Comment),
-            ScannerTestSlice("\n\n",                                            Token::Whitespace),
-            ScannerTestSlice("/***\r\n * These are not as well\n ***/",         Token::Comment),
-            ScannerTestSlice("\n",                                              Token::Whitespace),
-            ScannerTestSlice("//!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",                Token::DocComment),
-            ScannerTestSlice("\n",                                              Token::Whitespace),
-            ScannerTestSlice("//! Though this is one",                          Token::DocComment),
-            ScannerTestSlice("\n",                                              Token::Whitespace),
-            ScannerTestSlice("//!/////////////////////////////",                Token::DocComment),
-            ScannerTestSlice("\n \n ",                                          Token::Whitespace),
-            ScannerTestSlice("/////////////////////////////////",               Token::Comment),
-            ScannerTestSlice("\n",                                              Token::Whitespace),
-            ScannerTestSlice("/// It's a bit tricky...",                        Token::DocComment),
-            ScannerTestSlice("\n",                                              Token::Whitespace),
-            ScannerTestSlice("/////////////////////////////////",               Token::Comment),
-            ScannerTestSlice("\n\r\n",                                          Token::Whitespace),
-            ScannerTestSlice("/// As well as this one, and this:",              Token::DocComment),
-            ScannerTestSlice("\n",                                              Token::Whitespace),
-            ScannerTestSlice("///",                                             Token::DocComment),
-            ScannerTestSlice("\n\n",                                            Token::Whitespace),
-            ScannerTestSlice("/*!!! A doc-comment */",                          Token::DocComment),
-            ScannerTestSlice("\r\t\n",                                          Token::Whitespace),
-            ScannerTestSlice("/*!** A doc-comment as well **!*/",               Token::DocComment),
-            ScannerTestSlice("\n",                                              Token::Whitespace),
-            ScannerTestSlice("// This is not a doc comment:",                   Token::Comment),
-            ScannerTestSlice("\n",                                              Token::Whitespace),
-            ScannerTestSlice("/**/",                                            Token::Comment),
-            ScannerTestSlice("// But this one is:",                             Token::Comment),
-            ScannerTestSlice("\r\n",                                            Token::Whitespace),
-            ScannerTestSlice("/*!*/",                                           Token::DocComment),
-            ScannerTestSlice("// And this one isn't:",                          Token::Comment),
-            ScannerTestSlice("\n",                                              Token::Whitespace),
-            ScannerTestSlice("/***/",                                           Token::Comment),
-        ], &[], &[]);
+        check! {
+            ("/////////////////////////////////"                => Comment),
+            ("\n"                                               => Whitespace),
+            ("// These are not doc comments"                    => Comment),
+            ("\n"                                               => Whitespace),
+            ("/////////////////////////////////"                => Comment),
+            ("\n\n"                                             => Whitespace),
+            ("/***\r\n * These are not as well\n ***/"          => Comment),
+            ("\n"                                               => Whitespace),
+            ("//!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"                 => DocComment("//!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")),
+            ("\n"                                               => Whitespace),
+            ("//! Though this is one"                           => DocComment("//! Though this is one")),
+            ("\n"                                               => Whitespace),
+            ("//!/////////////////////////////"                 => DocComment("//!/////////////////////////////")),
+            ("\n \n "                                           => Whitespace),
+            ("/////////////////////////////////"                => Comment),
+            ("\n"                                               => Whitespace),
+            ("/// It's a bit tricky..."                         => DocComment("/// It's a bit tricky...")),
+            ("\n"                                               => Whitespace),
+            ("/////////////////////////////////"                => Comment),
+            ("\n\r\n"                                           => Whitespace),
+            ("/// As well as this one, and this:"               => DocComment("/// As well as this one, and this:")),
+            ("\n"                                               => Whitespace),
+            ("///"                                              => DocComment("///")),
+            ("\n\n"                                             => Whitespace),
+            ("/*!!! A doc-comment */"                           => DocComment("/*!!! A doc-comment */")),
+            ("\r\t\n"                                           => Whitespace),
+            ("/*!** A doc-comment as well **!*/"                => DocComment("/*!** A doc-comment as well **!*/")),
+            ("\n"                                               => Whitespace),
+            ("// This is not a doc comment:"                    => Comment),
+            ("\n"                                               => Whitespace),
+            ("/**/"                                             => Comment),
+            ("// But this one is:"                              => Comment),
+            ("\r\n"                                             => Whitespace),
+            ("/*!*/"                                            => DocComment("/*!*/")),
+            ("// And this one isn't:"                           => Comment),
+            ("\n"                                               => Whitespace),
+            ("/***/"                                            => Comment);
+        }
     }
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2030,44 +2176,44 @@ mod tests {
 
     #[test]
     fn brackets() {
-        check(&[
-            ScannerTestSlice("(",    Token::OpenDelim(Delimiter::Paren)),
-            ScannerTestSlice("]",    Token::CloseDelim(Delimiter::Bracket)),
-            ScannerTestSlice("\n\n", Token::Whitespace),
-            ScannerTestSlice("}",    Token::CloseDelim(Delimiter::Brace)),
-            ScannerTestSlice("}",    Token::CloseDelim(Delimiter::Brace)),
-            ScannerTestSlice(" ",    Token::Whitespace),
-            ScannerTestSlice("[",    Token::OpenDelim(Delimiter::Bracket)),
-            ScannerTestSlice("[",    Token::OpenDelim(Delimiter::Bracket)),
-            ScannerTestSlice("\t",   Token::Whitespace),
-            ScannerTestSlice("(",    Token::OpenDelim(Delimiter::Paren)),
-            ScannerTestSlice("{",    Token::OpenDelim(Delimiter::Brace)),
-            ScannerTestSlice("\r\n", Token::Whitespace),
-            ScannerTestSlice(")",    Token::CloseDelim(Delimiter::Paren)),
-            ScannerTestSlice(")",    Token::CloseDelim(Delimiter::Paren)),
-        ], &[], &[]);
+        check! {
+            ("("     => OpenDelim(Paren)),
+            ("]"     => CloseDelim(Bracket)),
+            ("\n\n"  => Whitespace),
+            ("}"     => CloseDelim(Brace)),
+            ("}"     => CloseDelim(Brace)),
+            (" "     => Whitespace),
+            ("["     => OpenDelim(Bracket)),
+            ("["     => OpenDelim(Bracket)),
+            ("\t"    => Whitespace),
+            ("("     => OpenDelim(Paren)),
+            ("{"     => OpenDelim(Brace)),
+            ("\r\n"  => Whitespace),
+            (")"     => CloseDelim(Paren)),
+            (")"     => CloseDelim(Paren));
+        }
     }
 
     #[test]
     fn punctuation() {
-        check(&[
-            ScannerTestSlice(",",  Token::Comma),
-            ScannerTestSlice(".",  Token::Dot),
-            ScannerTestSlice("::", Token::Dualcolon),
-            ScannerTestSlice(".",  Token::Dot),
-            ScannerTestSlice(":",  Token::Colon),
-            ScannerTestSlice(" ",  Token::Whitespace),
-            ScannerTestSlice(":",  Token::Colon),
-            ScannerTestSlice(".",  Token::Dot),
-            ScannerTestSlice(";",  Token::Semicolon),
-            ScannerTestSlice("(",  Token::OpenDelim(Delimiter::Paren)),
-            ScannerTestSlice(";",  Token::Semicolon),
-            ScannerTestSlice(";",  Token::Semicolon),
-            ScannerTestSlice(",",  Token::Comma),
-            ScannerTestSlice(",",  Token::Comma),
-            ScannerTestSlice("#",  Token::Hash),
-            ScannerTestSlice("#",  Token::Hash),
-        ], &[], &[]);
+        check! {
+            (","    => Comma),
+            ("."    => Dot),
+            ("::"   => Dualcolon),
+            ("."    => Dot),
+            (":"    => Colon),
+            (" "    => Whitespace),
+            (":"    => Colon),
+            ("."    => Dot),
+            (";"    => Semicolon),
+            ("("    => OpenDelim(Paren)),
+            (";"    => Semicolon),
+            (";"    => Semicolon),
+            (","    => Comma),
+            (","    => Comma),
+            ("#"    => Hash),
+            ("#"    => Hash);
+        }
     }
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2075,167 +2221,173 @@ mod tests {
 
     #[test]
     fn integer_basic_decimal() {
-        check(&[
-            ScannerTestSlice("0",     Token::Literal(Lit::Integer)),
-            ScannerTestSlice(",",     Token::Comma),
-            ScannerTestSlice("1",     Token::Literal(Lit::Integer)),
-            ScannerTestSlice(",",     Token::Comma),
-            ScannerTestSlice("00000", Token::Literal(Lit::Integer)),
-            ScannerTestSlice(",",     Token::Comma),
-            ScannerTestSlice("00001", Token::Literal(Lit::Integer)),
-            ScannerTestSlice(".",     Token::Dot),
-            ScannerTestSlice(" ",     Token::Whitespace),
-            ScannerTestSlice("42",    Token::Literal(Lit::Integer)),
-            ScannerTestSlice(" ",     Token::Whitespace),
-            ScannerTestSlice("9137847823642354637463430", Token::Literal(Lit::Integer)),
-            ScannerTestSlice("\n",    Token::Whitespace),
-            ScannerTestSlice("(",     Token::OpenDelim(Delimiter::Paren)),
-            ScannerTestSlice("12345", Token::Literal(Lit::Integer)),
-            ScannerTestSlice(")",     Token::CloseDelim(Delimiter::Paren)),
-            ScannerTestSlice("67890", Token::Literal(Lit::Integer)),
-        ], &[], &[]);
+        check! {
+            ("0"                        => Literal(Integer, "0")),
+            (","                        => Comma),
+            ("1"                        => Literal(Integer, "1")),
+            (","                        => Comma),
+            ("00000"                    => Literal(Integer, "00000")),
+            (","                        => Comma),
+            ("00001"                    => Literal(Integer, "00001")),
+            ("."                        => Dot),
+            (" "                        => Whitespace),
+            ("42"                       => Literal(Integer, "42")),
+            (" "                        => Whitespace),
+            ("913784782364235463746343" => Literal(Integer, "913784782364235463746343")),
+            ("\n"                       => Whitespace),
+            ("("                        => OpenDelim(Paren)),
+            ("12345"                    => Literal(Integer, "12345")),
+            (")"                        => CloseDelim(Paren)),
+            ("67890"                    => Literal(Integer, "67890"));
+        }
     }
 
     #[test]
     fn integer_basic_nondecimal() {
-        check(&[
-            ScannerTestSlice("0b0110101010",    Token::Literal(Lit::Integer)),
-            ScannerTestSlice(",",               Token::Comma),
-            ScannerTestSlice("0o755",           Token::Literal(Lit::Integer)),
-            ScannerTestSlice(",",               Token::Comma),
-            ScannerTestSlice("0o32",            Token::Literal(Lit::Integer)),
-            ScannerTestSlice(",",               Token::Comma),
-            ScannerTestSlice("0o0",             Token::Literal(Lit::Integer)),
-            ScannerTestSlice(",",               Token::Comma),
-            ScannerTestSlice("0xDBE",           Token::Literal(Lit::Integer)),
-            ScannerTestSlice(",",               Token::Comma),
-            ScannerTestSlice("0x12345",         Token::Literal(Lit::Integer)),
-            ScannerTestSlice(",",               Token::Comma),
-            ScannerTestSlice("0xDeadBeef",      Token::Literal(Lit::Integer)),
-            ScannerTestSlice(",",               Token::Comma),
-            ScannerTestSlice("0xAAAAAAAAAAAAA", Token::Literal(Lit::Integer)),
-        ], &[], &[]);
+        check! {
+            ("0b0110101010"             => Literal(Integer, "0b0110101010")),
+            (","                        => Comma),
+            ("0o755"                    => Literal(Integer, "0o755")),
+            (","                        => Comma),
+            ("0o32"                     => Literal(Integer, "0o32")),
+            (","                        => Comma),
+            ("0o0"                      => Literal(Integer, "0o0")),
+            (","                        => Comma),
+            ("0xDBE"                    => Literal(Integer, "0xDBE")),
+            (","                        => Comma),
+            ("0x12345"                  => Literal(Integer, "0x12345")),
+            (","                        => Comma),
+            ("0xDeadBeef"               => Literal(Integer, "0xDeadBeef")),
+            (","                        => Comma),
+            ("0xAAAAAAAAAAAAA"          => Literal(Integer, "0xAAAAAAAAAAAAA"));
+        }
     }
 
     #[test]
     fn integer_separators() {
-        check(&[
-            ScannerTestSlice("0___",       Token::Literal(Lit::Integer)),
-            ScannerTestSlice(" ",          Token::Whitespace),
-            ScannerTestSlice("10_000",     Token::Literal(Lit::Integer)),
-            ScannerTestSlice(" ",          Token::Whitespace),
-            ScannerTestSlice("1_2_3_4_5",  Token::Literal(Lit::Integer)),
-            ScannerTestSlice(" ",          Token::Whitespace),
-            ScannerTestSlice("0x__5__",    Token::Literal(Lit::Integer)),
-            ScannerTestSlice(" ",          Token::Whitespace),
-            ScannerTestSlice("0b_0_1_1_0", Token::Literal(Lit::Integer)),
-            ScannerTestSlice(" ",          Token::Whitespace),
-            ScannerTestSlice("0o_7_7_7_",  Token::Literal(Lit::Integer)),
-            ScannerTestSlice(" ",          Token::Whitespace),
-            ScannerTestSlice("0________0", Token::Literal(Lit::Integer)),
-        ], &[], &[]);
+        check! {
+            ("0___"                     => Literal(Integer, "0___")),
+            (" "                        => Whitespace),
+            ("10_000"                   => Literal(Integer, "10_000")),
+            (" "                        => Whitespace),
+            ("1_2_3_4_5"                => Literal(Integer, "1_2_3_4_5")),
+            (" "                        => Whitespace),
+            ("0x__5__"                  => Literal(Integer, "0x__5__")),
+            (" "                        => Whitespace),
+            ("0b_0_1_1_0"               => Literal(Integer, "0b_0_1_1_0")),
+            (" "                        => Whitespace),
+            ("0o_7_7_7_"                => Literal(Integer, "0o_7_7_7_")),
+            (" "                        => Whitespace),
+            ("0________0"               => Literal(Integer, "0________0"));
+        }
     }
 
     #[test]
     fn integer_unexpected_digit_range() {
-        check(&[
-            ScannerTestSlice("0b12345", Token::Literal(Lit::Integer)),
-            ScannerTestSlice(",",       Token::Comma),
-            ScannerTestSlice("0o48_19", Token::Literal(Lit::Integer)),
+        check! {
+            ("0b12345"                  => Literal(Integer, "0b12345")),
+            (","                        => Comma),
+            ("0o48_19"                  => Literal(Integer, "0o48_19"));
             // There are no unexpected characters in decimal or hexadecimal literals.
             // The first nondigit is either the start of a type suffix, or the first
             // character of the next token.
-        ], &[ Span::new(3, 4), Span::new(4, 5), Span::new(5, 6), Span::new(6, 7),
-              Span::new(11, 12), Span::new(14, 15)], &[]);
+        Severity::Error:
+            (3, 4), (4, 5), (5, 6), (6, 7), (11, 12), (14, 15);
+        }
     }
 
     #[test]
     fn integer_unexpected_nondecimal_termination() {
-        check(&[
-            ScannerTestSlice("0x",  Token::Literal(Lit::Integer)),
-            ScannerTestSlice(",",   Token::Comma),
-            ScannerTestSlice("0b",  Token::Literal(Lit::Integer)),
-            ScannerTestSlice(",",   Token::Comma),
-            ScannerTestSlice("0o",  Token::Literal(Lit::Integer)),
-            ScannerTestSlice(",",   Token::Comma),
-            ScannerTestSlice("0x_", Token::Literal(Lit::Integer)),
-            ScannerTestSlice(",",   Token::Comma),
-            ScannerTestSlice("0b_", Token::Literal(Lit::Integer)),
-            ScannerTestSlice(",",   Token::Comma),
-            ScannerTestSlice("0o_", Token::Literal(Lit::Integer)),
-        ], &[ Span::new(0, 2), Span::new(3, 5), Span::new(6, 8), Span::new(9, 12),
-              Span::new(13, 16), Span::new(17, 20) ], &[]);
+        check! {
+            ("0x"                       => Literal(Integer, "0x")),
+            (","                        => Comma),
+            ("0b"                       => Literal(Integer, "0b")),
+            (","                        => Comma),
+            ("0o"                       => Literal(Integer, "0o")),
+            (","                        => Comma),
+            ("0x_"                      => Literal(Integer, "0x_")),
+            (","                        => Comma),
+            ("0b_"                      => Literal(Integer, "0b_")),
+            (","                        => Comma),
+            ("0o_"                      => Literal(Integer, "0o_"));
+
+        Severity::Error:
+            (0, 2), (3, 5), (6, 8), (9, 12), (13, 16), (17, 20);
+        }
     }
 
     // TODO: combined errors
 
     #[test]
     fn integer_type_suffixes() {
-        check(&[
+        check! {
             // ASCII suffixes
-            ScannerTestSlice("1foo",                    Token::Literal(Lit::Integer)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("42i32",                   Token::Literal(Lit::Integer)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
+            ("1foo"                     => Literal(Integer, "1", "foo")),
+            (" "                        => Whitespace),
+            ("42i32"                    => Literal(Integer, "42", "i32")),
+            (" "                        => Whitespace),
             // Only words can be suffixes
-            ScannerTestSlice("42",                      Token::Literal(Lit::Integer)),
-            ScannerTestSlice("+",                       Token::Identifier),
-            ScannerTestSlice("i32",                     Token::Identifier),
-            ScannerTestSlice(" ",                       Token::Whitespace),
+            ("42"                       => Literal(Integer, "42")),
+            ("+"                        => Identifier("+")),
+            ("i32"                      => Identifier("i32")),
+            (" "                        => Whitespace),
             // Leading zero is not special
-            ScannerTestSlice("0yFFF",                   Token::Literal(Lit::Integer)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("0xBREAD",                 Token::Literal(Lit::Integer)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("0_o133",                  Token::Literal(Lit::Integer)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
+            ("0yFFF"                    => Literal(Integer, "0", "yFFF")),
+            (" "                        => Whitespace),
+            ("0xBREAD"                  => Literal(Integer, "0xB", "READ")),
+            (" "                        => Whitespace),
+            ("0_o133"                   => Literal(Integer, "0_", "o133")),
+            (" "                        => Whitespace),
             // Unicode suffixes
-            ScannerTestSlice("983\u{7206}\u{767A}",     Token::Literal(Lit::Integer)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("983\\u{7206}\\u{767A}",   Token::Literal(Lit::Integer)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
+            ("983\u{7206}\u{767A}"      => Literal(Integer, "983", "\u{7206}\u{767A}")),
+            (" "                        => Whitespace),
+            ("983\\u{7206}\\u{767A}"    => Literal(Integer, "983", "\u{7206}\u{767A}")),
+            (" "                        => Whitespace),
             // This is binary literal, not zero with suffix
-            ScannerTestSlice("0b234",                   Token::Literal(Lit::Integer)),
-        ], &[ Span::new(71, 72), Span::new(72, 73), Span::new(73, 74) ], &[]);
+            ("0b234"                    => Literal(Integer, "0b234"));
+
+        Severity::Error:
+            (71, 72), (72, 73), (73, 74);
+        }
     }
 
     #[test]
     fn integer_type_suffixes_invalid() {
-        check(&[
+        check! {
             // Inner invalid characters are treated as constituents of suffixes,
             // just as in regular identifiers. Note that underscores are treated
             // as a part of the number.
-            ScannerTestSlice("45f\\u{D800}9",           Token::Literal(Lit::Integer)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("951_x\u{0}__",            Token::Literal(Lit::Integer)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("0000\\u430\\u443",        Token::Literal(Lit::Integer)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("9_x\\u{78}__",            Token::Literal(Lit::Integer)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("542_o\\x10",              Token::Literal(Lit::Integer)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
+            ("45f\\u{D800}9"            => Literal(Integer, "45", "f\u{FFFD}9")),
+            (" "                        => Whitespace),
+            ("951_x\u{0}__"             => Literal(Integer, "951_", "x\u{0}__")),
+            (" "                        => Whitespace),
+            ("0000\\u430\\u443"         => Literal(Integer, "0000", "\u{0430}\u{0443}")),
+            (" "                        => Whitespace),
+            ("9_x\\u{78}__"             => Literal(Integer, "9_", "x\u{FFFD}__")),
+            (" "                        => Whitespace),
+            ("542_o\\x10"               => Literal(Integer, "542_", "o\\x10")),
+            (" "                        => Whitespace),
             // However, if a literal is immediately followed by an invalid characters
             // they are not scanned over in anticipation of suffix. They are instantly
             // treated as Token::Unrecognized following the literal
-            ScannerTestSlice("0000",                    Token::Literal(Lit::Integer)),
-            ScannerTestSlice("\u{0}\u{0}",              Token::Unrecognized),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("951__",                   Token::Literal(Lit::Integer)),
-            ScannerTestSlice("\u{0}",                   Token::Unrecognized),
-            ScannerTestSlice("__",                      Token::Identifier),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("9__",                     Token::Literal(Lit::Integer)),
-            ScannerTestSlice("\\u{DAAA}\\u{78}",        Token::Unrecognized),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("542_",                    Token::Literal(Lit::Integer)),
-            ScannerTestSlice("\\",                      Token::Unrecognized),
-            ScannerTestSlice("x10",                     Token::Identifier),
-        ], &[
-            Span::new( 3, 11), Span::new(18, 19), Span::new(28, 31), Span::new(33, 36),
-            Span::new(40, 46), Span::new(54, 55), Span::new(63, 65), Span::new(71, 72),
-            Span::new(78, 86), Span::new(78, 92), Span::new(97, 98)
-        ], &[]);
+            ("0000"                     => Literal(Integer, "0000")),
+            ("\u{0}\u{0}"               => Unrecognized),
+            (" "                        => Whitespace),
+            ("951__"                    => Literal(Integer, "951__")),
+            ("\u{0}"                    => Unrecognized),
+            ("__"                       => Identifier("__")),
+            (" "                        => Whitespace),
+            ("9__"                      => Literal(Integer, "9__")),
+            ("\\u{DAAA}\\u{78}"         => Unrecognized),
+            (" "                        => Whitespace),
+            ("542_"                     => Literal(Integer, "542_")),
+            ("\\"                       => Unrecognized),
+            ("x10"                      => Identifier("x10"));
+
+        Severity::Error:
+            ( 3, 11), (18, 19), (28, 31), (33, 36), (40, 46), (54, 55), (63, 65), (71, 72),
+            (78, 86), (78, 92), (97, 98);
+        }
     }
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2243,185 +2395,189 @@ mod tests {
 
     #[test]
     fn float_basic() {
-        check(&[
-            ScannerTestSlice("0.0",             Token::Literal(Lit::Float)),
-            ScannerTestSlice(" ",               Token::Whitespace),
-            ScannerTestSlice("1.0",             Token::Literal(Lit::Float)),
-            ScannerTestSlice(" ",               Token::Whitespace),
-            ScannerTestSlice("12313.123123121", Token::Literal(Lit::Float)),
-            ScannerTestSlice(" ",               Token::Whitespace),
-            ScannerTestSlice("0.0000000005",    Token::Literal(Lit::Float)),
-            ScannerTestSlice(" ",               Token::Whitespace),
-            ScannerTestSlice("0000000.1200000", Token::Literal(Lit::Float)),
-            ScannerTestSlice(" ",               Token::Whitespace),
-            ScannerTestSlice("56.43453",        Token::Literal(Lit::Float)),
-        ], &[], &[]);
+        check! {
+            ("0.0"                      => Literal(Float, "0.0")),
+            (" "                        => Whitespace),
+            ("1.0"                      => Literal(Float, "1.0")),
+            (" "                        => Whitespace),
+            ("12313.123123121"          => Literal(Float, "12313.123123121")),
+            (" "                        => Whitespace),
+            ("0.0000000005"             => Literal(Float, "0.0000000005")),
+            (" "                        => Whitespace),
+            ("0000000.1200000"          => Literal(Float, "0000000.1200000")),
+            (" "                        => Whitespace),
+            ("56.43453"                 => Literal(Float, "56.43453"));
+        }
     }
 
     #[test]
     fn float_exponential_without_dot() {
-        check(&[
-            ScannerTestSlice("9e10",        Token::Literal(Lit::Float)),
-            ScannerTestSlice(",",           Token::Comma),
-            ScannerTestSlice("1400e+12313", Token::Literal(Lit::Float)),
-            ScannerTestSlice(",",           Token::Comma),
-            ScannerTestSlice("1400E-2323",  Token::Literal(Lit::Float)),
-            ScannerTestSlice("//",          Token::Comment),
-            ScannerTestSlice("\n",          Token::Whitespace),
-            ScannerTestSlice("0e+0",        Token::Literal(Lit::Float)),
-            ScannerTestSlice(",",           Token::Comma),
-            ScannerTestSlice("0001E1000",   Token::Literal(Lit::Float)),
-            ScannerTestSlice(",",           Token::Comma),
-            ScannerTestSlice("0e-0",        Token::Literal(Lit::Float)),
-        ], &[], &[]);
+        check! {
+            ("9e10"                     => Literal(Float, "9e10")),
+            (","                        => Comma),
+            ("1400e+12313"              => Literal(Float, "1400e+12313")),
+            (","                        => Comma),
+            ("1400E-2323"               => Literal(Float, "1400E-2323")),
+            ("//"                       => Comment),
+            ("\n"                       => Whitespace),
+            ("0e+0"                     => Literal(Float, "0e+0")),
+            (","                        => Comma),
+            ("0001E1000"                => Literal(Float, "0001E1000")),
+            (","                        => Comma),
+            ("0e-0"                     => Literal(Float, "0e-0"));
+        }
     }
 
     #[test]
     fn float_exponential_with_dot() {
-        check(&[
-            ScannerTestSlice("2.0E10",           Token::Literal(Lit::Float)),
-            ScannerTestSlice(")",                Token::CloseDelim(Delimiter::Paren)),
-            ScannerTestSlice("0.00000e0",        Token::Literal(Lit::Float)),
-            ScannerTestSlice("[",                Token::OpenDelim(Delimiter::Bracket)),
-            ScannerTestSlice("123.456e+789",     Token::Literal(Lit::Float)),
-            ScannerTestSlice("}",                Token::CloseDelim(Delimiter::Brace)),
-            ScannerTestSlice("11.11E-11",        Token::Literal(Lit::Float)),
-            ScannerTestSlice("{",                Token::OpenDelim(Delimiter::Brace)),
-            ScannerTestSlice("9363.83929e00434", Token::Literal(Lit::Float)),
-        ], &[], &[]);
+        check! {
+            ("2.0E10"                   => Literal(Float, "2.0E10")),
+            (")"                        => CloseDelim(Paren)),
+            ("0.00000e0"                => Literal(Float, "0.00000e0")),
+            ("["                        => OpenDelim(Bracket)),
+            ("123.456e+789"             => Literal(Float, "123.456e+789")),
+            ("}"                        => CloseDelim(Brace)),
+            ("11.11E-11"                => Literal(Float, "11.11E-11")),
+            ("{"                        => OpenDelim(Brace)),
+            ("9363.83929e00434"         => Literal(Float, "9363.83929e00434"));
+        }
     }
 
     #[test]
     fn float_extreme() {
         // Just making sure that scanner does not care about semantics
-        check(&[
-            ScannerTestSlice("999999999999999999999999.999999999999999999", Token::Literal(Lit::Float)),
-            ScannerTestSlice("\r\n",                                        Token::Whitespace),
-            ScannerTestSlice("0.0000000000000000000e-99999999999999999999", Token::Literal(Lit::Float)),
-            ScannerTestSlice("\r\n",                                        Token::Whitespace),
-            ScannerTestSlice("1.2345678901234567890E+12345678901234567890", Token::Literal(Lit::Float)),
-            ScannerTestSlice("\r\n",                                        Token::Whitespace),
-            ScannerTestSlice("12345678.901234567890E123456789012345678901", Token::Literal(Lit::Float)),
-        ], &[], &[]);
+        check! {
+            ("999999999999999999999999.99999999999999" => Literal(Float, "999999999999999999999999.99999999999999")),
+            ("\r\n"                                    => Whitespace),
+            ("0.0000000000000000000e-9999999999999999" => Literal(Float, "0.0000000000000000000e-9999999999999999")),
+            ("\r\n"                                    => Whitespace),
+            ("1.2345678901234567890E+1234567890123456" => Literal(Float, "1.2345678901234567890E+1234567890123456")),
+            ("\r\n"                                    => Whitespace),
+            ("12345678.901234567890E12345678901234567" => Literal(Float, "12345678.901234567890E12345678901234567"));
+        }
     }
 
     #[test]
     fn float_separators() {
-        check(&[
-            ScannerTestSlice("10_000.000_001", Token::Literal(Lit::Float)),
-            ScannerTestSlice(",",              Token::Comma),
-            ScannerTestSlice("0______0.5",     Token::Literal(Lit::Float)),
-            ScannerTestSlice(":",              Token::Colon),
-            ScannerTestSlice("1_._2",          Token::Literal(Lit::Float)),
-            ScannerTestSlice(",",              Token::Comma),
-            ScannerTestSlice("3._4_",          Token::Literal(Lit::Float)),
-            ScannerTestSlice(":",              Token::Colon),
-            ScannerTestSlice("7___e54",        Token::Literal(Lit::Float)),
-            ScannerTestSlice(",",              Token::Comma),
-            ScannerTestSlice("3_._1_E_4",      Token::Literal(Lit::Float)),
-            ScannerTestSlice(":",              Token::Colon),
-            ScannerTestSlice("0.0e+___4",      Token::Literal(Lit::Float)),
-            ScannerTestSlice(",",              Token::Comma),
-            ScannerTestSlice("0._0E-__5__",    Token::Literal(Lit::Float)),
-        ], &[], &[]);
+        check! {
+            ("10_000.000_001"           => Literal(Float, "10_000.000_001")),
+            (","                        => Comma),
+            ("0______0.5"               => Literal(Float, "0______0.5")),
+            (":"                        => Colon),
+            ("1_._2"                    => Literal(Float, "1_._2")),
+            (","                        => Comma),
+            ("3._4_"                    => Literal(Float, "3._4_")),
+            (":"                        => Colon),
+            ("7___e54"                  => Literal(Float, "7___e54")),
+            (","                        => Comma),
+            ("3_._1_E_4"                => Literal(Float, "3_._1_E_4")),
+            (":"                        => Colon),
+            ("0.0e+___4"                => Literal(Float, "0.0e+___4")),
+            (","                        => Comma),
+            ("0._0E-__5__"              => Literal(Float, "0._0E-__5__"));
+        }
     }
 
     #[test]
     fn float_deny_radix_spec() {
-        check(&[
-            ScannerTestSlice("0b1e101101",         Token::Literal(Lit::Float)),
-            ScannerTestSlice("          ",         Token::Whitespace),
-            ScannerTestSlice("0b01011011.0110101", Token::Literal(Lit::Float)),
-            ScannerTestSlice("/*      */",         Token::Comment),
-            ScannerTestSlice("0o7.7",              Token::Literal(Lit::Float)),
-            ScannerTestSlice("          ",         Token::Whitespace),
-            ScannerTestSlice("0o77e10",            Token::Literal(Lit::Float)),
-            ScannerTestSlice("          ",         Token::Whitespace),
-            ScannerTestSlice("0x00.0E7",           Token::Literal(Lit::Float)),
-            ScannerTestSlice("          ",         Token::Whitespace),
-            ScannerTestSlice("0x5.1",              Token::Literal(Lit::Float)),
-            ScannerTestSlice("          ",         Token::Whitespace),
-            ScannerTestSlice("0o5e+3",             Token::Literal(Lit::Float)),
-        ], &[ Span::new(0, 10), Span::new(20, 38), Span::new(48, 53), Span::new(63, 70),
-              Span::new(80, 88), Span::new(98, 103), Span::new(113, 119) ], &[]);
+        check! {
+            ("0b1e101101"               => Literal(Float, "0b1e101101")),
+            ("          "               => Whitespace),
+            ("0b01011011.011010"        => Literal(Float, "0b01011011.011010")),
+            ("/*      */"               => Comment),
+            ("0o7.7"                    => Literal(Float, "0o7.7")),
+            ("          "               => Whitespace),
+            ("0o77e10"                  => Literal(Float, "0o77e10")),
+            ("          "               => Whitespace),
+            ("0x00.0E7"                 => Literal(Float, "0x00.0E7")),
+            ("          "               => Whitespace),
+            ("0x5.1"                    => Literal(Float, "0x5.1")),
+            ("          "               => Whitespace),
+            ("0o5e+3"                   => Literal(Float, "0o5e+3"));
+
+        Severity::Error:
+            (0, 10), (20, 37), (47, 52), (62, 69), (79, 87), (97, 102), (112, 118);
+        }
     }
 
     #[test]
     fn float_missing_numbers() {
-        check(&[
-            ScannerTestSlice("5._____",        Token::Literal(Lit::Float)),
-            ScannerTestSlice(",",              Token::Comma),
-            ScannerTestSlice("0._",            Token::Literal(Lit::Float)),
-            ScannerTestSlice(",",              Token::Comma),
-            ScannerTestSlice("1e___",          Token::Literal(Lit::Float)),
-            ScannerTestSlice(",",              Token::Comma),
-            ScannerTestSlice("5.0E+___",       Token::Literal(Lit::Float)),
-            ScannerTestSlice(",",              Token::Comma),
-            ScannerTestSlice("10e-___",        Token::Literal(Lit::Float)),
-        ], &[ Span::new(2, 7), Span::new(10, 11), Span::new(14, 17),
-              Span::new(23, 26), Span::new(31, 34) ], &[]);
+        check! {
+            ("5._____"                  => Literal(Float, "5._____")),
+            (","                        => Comma),
+            ("0._"                      => Literal(Float, "0._")),
+            (","                        => Comma),
+            ("1e___"                    => Literal(Float, "1e___")),
+            (","                        => Comma),
+            ("5.0E+___"                 => Literal(Float, "5.0E+___")),
+            (","                        => Comma),
+            ("10e-___"                  => Literal(Float, "10e-___"));
+
+        Severity::Error:
+            (2, 7), (10, 11), (14, 17), (23, 26), (31, 34);
+        }
     }
 
     // TODO: combined errors
 
     #[test]
     fn float_type_suffixes() {
-        check(&[
+        check! {
             // ASCII suffixes
-            ScannerTestSlice("1.0zog",                      Token::Literal(Lit::Float)),
-            ScannerTestSlice(" ",                           Token::Whitespace),
-            ScannerTestSlice("0e+10f32",                    Token::Literal(Lit::Float)),
-            ScannerTestSlice(" ",                           Token::Whitespace),
+            ("1.0zog"                       => Literal(Float, "1.0", "zog")),
+            (" "                            => Whitespace),
+            ("0e+10f32"                     => Literal(Float, "0e+10", "f32")),
+            (" "                            => Whitespace),
             // Only words can be suffixes
-            ScannerTestSlice("56e",                         Token::Literal(Lit::Integer)),
-            ScannerTestSlice("=",                           Token::Identifier),
-            ScannerTestSlice("_f64",                        Token::Identifier),
-            ScannerTestSlice(" ",                           Token::Whitespace),
+            ("56e"                          => Literal(Integer, "56", "e")),
+            ("="                            => Identifier("=")),
+            ("_f64"                         => Identifier("_f64")),
+            (" "                            => Whitespace),
             // Unicode suffixes
-            ScannerTestSlice("0.0_\u{7206}\u{767A}",        Token::Literal(Lit::Float)),
-            ScannerTestSlice(" ",                           Token::Whitespace),
-            ScannerTestSlice("9.6E-7_8\\u{7206}\\u{767A}",  Token::Literal(Lit::Float)),
-            ScannerTestSlice(" ",                           Token::Whitespace),
-        ], &[], &[]);
+            ("0.0_\u{7206}\u{767A}"         => Literal(Float, "0.0_", "\u{7206}\u{767A}")),
+            (" "                            => Whitespace),
+            ("9.6E-7_8\\u{7206}\\u{767A}"   => Literal(Float, "9.6E-7_8", "\u{7206}\u{767A}")),
+            (" "                            => Whitespace);
+        }
     }
 
     #[test]
     fn float_type_suffixes_invalid() {
-        check(&[
+        check! {
             // Inner invalid characters are treated as constituents of suffixes,
             // just as in regular identifiers. Note that underscores are treated
             // as a part of the number.
-            ScannerTestSlice("4.5f\\u{D800}9",          Token::Literal(Lit::Float)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("9e0_x\u{0}__",            Token::Literal(Lit::Float)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("0.000\\u{430\\u443}",     Token::Literal(Lit::Float)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("9_e\\u{78}__",            Token::Literal(Lit::Integer)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("50_e+2_o\\\\10",          Token::Literal(Lit::Float)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
+            ("4.5f\\u{D800}9"               => Literal(Float, "4.5", "f\u{FFFD}9")),
+            (" "                            => Whitespace),
+            ("9e0_x\u{0}__"                 => Literal(Float, "9e0_", "x\u{0}__")),
+            (" "                            => Whitespace),
+            ("0.000\\u{430\\u443}"          => Literal(Float, "0.000", "\u{0430}\u{0443}")),
+            (" "                            => Whitespace),
+            ("9_e\\u{78}__"                 => Literal(Integer, "9_", "e\u{FFFD}__")),
+            (" "                            => Whitespace),
+            ("50_e+2_o\\\\10"               => Literal(Float, "50_e+2_", "o\\\\10")),
+            (" "                            => Whitespace),
             // However, if a literal is immediately followed by an invalid characters
             // they are not scanned over in anticipation of suffix. They are instantly
             // treated as Token::Unrecognized following the literal
-            ScannerTestSlice("00.0",                    Token::Literal(Lit::Float)),
-            ScannerTestSlice("\u{0}\u{1}",              Token::Unrecognized),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("9.1_e+5_",                Token::Literal(Lit::Float)),
-            ScannerTestSlice("\u{5}",                   Token::Unrecognized),
-            ScannerTestSlice("__",                      Token::Identifier),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("9E1_",                    Token::Literal(Lit::Float)),
-            ScannerTestSlice("\\u{DEAD}\\u{31}",        Token::Unrecognized),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("5.0_",                    Token::Literal(Lit::Float)),
-            ScannerTestSlice("\\",                      Token::Unrecognized),
-            ScannerTestSlice("e10",                     Token::Identifier),
-        ], &[
-            Span::new(  4,  12), Span::new( 19,  20), Span::new( 34,  34), Span::new( 36,  36),
-            Span::new( 44,  50), Span::new( 61,  62), Span::new( 62,  63), Span::new( 70,  72),
-            Span::new( 81,  82), Span::new( 89,  97), Span::new( 89, 103), Span::new(108, 109)
-        ], &[]);
+            ("00.0"                         => Literal(Float, "00.0")),
+            ("\u{0}\u{1}"                   => Unrecognized),
+            (" "                            => Whitespace),
+            ("9.1_e+5_"                     => Literal(Float, "9.1_e+5_")),
+            ("\u{5}"                        => Unrecognized),
+            ("__"                           => Identifier("__")),
+            (" "                            => Whitespace),
+            ("9E1_"                         => Literal(Float, "9E1_")),
+            ("\\u{DEAD}\\u{31}"             => Unrecognized),
+            (" "                            => Whitespace),
+            ("5.0_"                         => Literal(Float, "5.0_")),
+            ("\\"                           => Unrecognized),
+            ("e10"                          => Identifier("e10"));
+
+        Severity::Error:
+            (  4,  12), ( 19,  20), ( 34,  34), ( 36,  36), ( 44,  50), ( 61,  62), ( 62,  63),
+            ( 70,  72), ( 81,  82), ( 89,  97), ( 89, 103), (108, 109);
+        }
     }
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2429,123 +2585,135 @@ mod tests {
 
     #[test]
     fn character_ascii() {
-        check(&[
-            ScannerTestSlice("'a'",  Token::Literal(Lit::Character)),
-            ScannerTestSlice("   ",  Token::Whitespace),
-            ScannerTestSlice("'b'",  Token::Literal(Lit::Character)),
-            ScannerTestSlice("   ",  Token::Whitespace),
-            ScannerTestSlice("'0'",  Token::Literal(Lit::Character)),
-            ScannerTestSlice("   ",  Token::Whitespace),
-            ScannerTestSlice("'''",  Token::Literal(Lit::Character)),
-            ScannerTestSlice("   ",  Token::Whitespace),
-            ScannerTestSlice("' '",  Token::Literal(Lit::Character)),
-            ScannerTestSlice("   ",  Token::Whitespace),
-            ScannerTestSlice("'''",  Token::Literal(Lit::Character)),
-            ScannerTestSlice("'''",  Token::Literal(Lit::Character)),
-            ScannerTestSlice("'\"'", Token::Literal(Lit::Character)),
-        ], &[], &[]);
+        check! {
+            ("'a'"              => Literal(Character, "a")),
+            ("   "              => Whitespace),
+            ("'b'"              => Literal(Character, "b")),
+            ("   "              => Whitespace),
+            ("'0'"              => Literal(Character, "0")),
+            ("   "              => Whitespace),
+            ("'''"              => Literal(Character, "'")),
+            ("   "              => Whitespace),
+            ("' '"              => Literal(Character, " ")),
+            ("   "              => Whitespace),
+            ("'''"              => Literal(Character, "'")),
+            ("'''"              => Literal(Character, "'")),
+            ("'\"'"             => Literal(Character, "\""));
+        }
     }
 
     #[test]
     fn character_unicode() {
-        check(&[
+        check! {
             // Surrogates are not valid UTF-8 text and should have been reported before.
             // Rust does not even allow placing them into strings.
-            ScannerTestSlice("'\u{0123}'",   Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",            Token::Whitespace),
-            ScannerTestSlice("'\u{07F7}'",   Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",            Token::Whitespace),
-            ScannerTestSlice("'\u{10ba}'",   Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",            Token::Whitespace),
-            ScannerTestSlice("'\u{B0e6}'",   Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",            Token::Whitespace),
-            ScannerTestSlice("'\u{100300}'", Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",            Token::Whitespace),
-            ScannerTestSlice("'\u{0103CA}'", Token::Literal(Lit::Character)),
-        ], &[], &[]);
+            ("'\u{0123}'"       => Literal(Character, "\u{0123}")),
+            (" "                => Whitespace),
+            ("'\u{07F7}'"       => Literal(Character, "\u{07F7}")),
+            (" "                => Whitespace),
+            ("'\u{10ba}'"       => Literal(Character, "\u{10ba}")),
+            (" "                => Whitespace),
+            ("'\u{B0e6}'"       => Literal(Character, "\u{B0e6}")),
+            (" "                => Whitespace),
+            ("'\u{100300}'"     => Literal(Character, "\u{100300}")),
+            (" "                => Whitespace),
+            ("'\u{0103CA}'"     => Literal(Character, "\u{0103CA}"));
+        }
     }
 
     #[test]
     fn character_control() {
-        check(&[
-            ScannerTestSlice("'\0'",   Token::Literal(Lit::Character)),  // Control characters can be used in
-            ScannerTestSlice(" ",      Token::Whitespace), // character literals (technically).
-            ScannerTestSlice("'\t'",   Token::Literal(Lit::Character)),  // They can be rendered weirdly by text
-            ScannerTestSlice(" ",      Token::Whitespace), // editors, but we do not care much.
-            ScannerTestSlice("'\x04'", Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",      Token::Whitespace),
-            ScannerTestSlice("'\x08'", Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",      Token::Whitespace),
-            ScannerTestSlice("'\x0B'", Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",      Token::Whitespace),
-            ScannerTestSlice("'\x7F'", Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",      Token::Whitespace),
-            ScannerTestSlice("'\u{2028}'", Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",          Token::Whitespace),
-            ScannerTestSlice("'\u{2029}'", Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",          Token::Whitespace),
-            ScannerTestSlice("'\u{0086}'", Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",          Token::Whitespace),
-        ], &[], &[]);
+        check! {
+            // Control characters can be used in character literals (technically).
+            // They can be rendered weirdly by text editors, but we do not care much.
+            ("'\0'"             => Literal(Character, "\0")),
+            (" "                => Whitespace),
+            ("'\t'"             => Literal(Character, "\t")),
+            (" "                => Whitespace),
+            ("'\x04'"           => Literal(Character, "\x04")),
+            (" "                => Whitespace),
+            ("'\x08'"           => Literal(Character, "\x08")),
+            (" "                => Whitespace),
+            ("'\x0B'"           => Literal(Character, "\x0B")),
+            (" "                => Whitespace),
+            ("'\x7F'"           => Literal(Character, "\x7F")),
+            (" "                => Whitespace),
+            ("'\u{2028}'"       => Literal(Character, "\u{2028}")),
+            (" "                => Whitespace),
+            ("'\u{2029}'"       => Literal(Character, "\u{2029}")),
+            (" "                => Whitespace),
+            ("'\u{0086}'"       => Literal(Character, "\u{0086}")),
+            (" "                => Whitespace);
+        }
     }
 
     #[test]
     fn character_escape_sequences() {
-        check(&[
-            ScannerTestSlice(r"'\0'",  Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",      Token::Whitespace),
-            ScannerTestSlice(r"'\t'",  Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",      Token::Whitespace),
-            ScannerTestSlice(r"'\r'",  Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",      Token::Whitespace),
-            ScannerTestSlice(r"'\n'",  Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",      Token::Whitespace),
-            ScannerTestSlice(r"'\'",   Token::Literal(Lit::Character)), // backslash alone is okay
-            ScannerTestSlice(" ",      Token::Whitespace),
-            ScannerTestSlice(r"'\\'",  Token::Literal(Lit::Character)), // escaped is fine as well
-            ScannerTestSlice(" ",      Token::Whitespace),
-            ScannerTestSlice("'\\\"'", Token::Literal(Lit::Character)), // escaped double-quote
-        ], &[], &[]);                                     // can be copy-pasted from strings
+        check! {
+            (r"'\0'"            => Literal(Character, "\0")),
+            (" "                => Whitespace),
+            (r"'\t'"            => Literal(Character, "\t")),
+            (" "                => Whitespace),
+            (r"'\r'"            => Literal(Character, "\r")),
+            (" "                => Whitespace),
+            (r"'\n'"            => Literal(Character, "\n")),
+            (" "                => Whitespace),
+            // Backslash alone is okay
+            (r"'\'"             => Literal(Character, "\\")),
+            (" "                => Whitespace),
+            // Escaped one is fine as well
+            (r"'\\'"            => Literal(Character, "\\")),
+            (" "                => Whitespace),
+            // Escaped double-quote can be copy-pasted from strings
+            ("'\\\"'"           => Literal(Character, "\""));
+        }
     }
 
     #[test]
     fn character_unicode_escapes() {
-        check(&[
-            ScannerTestSlice(r"'\x00'",         Token::Literal(Lit::Character)),
-            ScannerTestSlice(r" ",              Token::Whitespace),
-            ScannerTestSlice(r"'\x35'",         Token::Literal(Lit::Character)),
-            ScannerTestSlice(r" ",              Token::Whitespace),
-            ScannerTestSlice(r"'\x1f'",         Token::Literal(Lit::Character)),
-            ScannerTestSlice(r" ",              Token::Whitespace),
-            ScannerTestSlice(r"'\xFF'",         Token::Literal(Lit::Character)),  // \x?? escapes are ASCII-only
-            ScannerTestSlice(r" ",              Token::Whitespace),
-            ScannerTestSlice(r"'\u{12}'",       Token::Literal(Lit::Character)),
-            ScannerTestSlice(r" ",              Token::Whitespace),
-            ScannerTestSlice(r"'\u{d799}'",     Token::Literal(Lit::Character)),
-            ScannerTestSlice(r" ",              Token::Whitespace),
-            ScannerTestSlice(r"'\u{D800}'",     Token::Literal(Lit::Character)),  // Surrogates are not valid
-            ScannerTestSlice(r" ",              Token::Whitespace),
-            ScannerTestSlice(r"'\u{DEAD}'",     Token::Literal(Lit::Character)),  // All of them
-            ScannerTestSlice(r" ",              Token::Whitespace),
-            ScannerTestSlice(r"'\u{DFfF}'",     Token::Literal(Lit::Character)),  // are not valid
-            ScannerTestSlice(r" ",              Token::Whitespace),
-            ScannerTestSlice(r"'\u{e000}'",     Token::Literal(Lit::Character)),
-            ScannerTestSlice(r" ",              Token::Whitespace),
-            ScannerTestSlice(r"'\u{FFFE}'",     Token::Literal(Lit::Character)),  // Non-characters are okay
-            ScannerTestSlice(r" ",              Token::Whitespace),
-            ScannerTestSlice(r"'\u{fffff}'",    Token::Literal(Lit::Character)),
-            ScannerTestSlice(r" ",              Token::Whitespace),
-            ScannerTestSlice(r"'\u{F0123}'",    Token::Literal(Lit::Character)),  // Private use area is okay
-            ScannerTestSlice(r" ",              Token::Whitespace),
-            ScannerTestSlice(r"'\u{0}'",        Token::Literal(Lit::Character)),
-            ScannerTestSlice(r" ",              Token::Whitespace),
-            ScannerTestSlice(r"'\u{00000005}'", Token::Literal(Lit::Character)),
-            ScannerTestSlice(r" ",              Token::Whitespace),
-            ScannerTestSlice(r"'\u{99999999}'", Token::Literal(Lit::Character)),  // Out of range are not okay
-            ScannerTestSlice(r" ",              Token::Whitespace), // but they are still scanned
-            ScannerTestSlice(r"'\u{f0f0f0deadbeef00012345}'", Token::Literal(Lit::Character)),
-        ], &[ Span::new( 22 , 26), Span::new( 49 , 57), Span::new(60, 68), Span::new(71, 79),
-              Span::new(151, 163), Span::new(166, 192) ], &[]);
+        check! {
+            (r"'\x00'"          => Literal(Character, "\x00")),
+            (r" "               => Whitespace),
+            (r"'\x35'"          => Literal(Character, "\x35")),
+            (r" "               => Whitespace),
+            (r"'\x1f'"          => Literal(Character, "\x1f")),
+            (r" "               => Whitespace),
+            // \x?? escapes are ASCII-only
+            (r"'\xFF'"          => Literal(Character, "\u{FFFD}")),
+            (r" "               => Whitespace),
+            (r"'\u{12}'"        => Literal(Character, "\u{12}")),
+            (r" "               => Whitespace),
+            // Surrogates are not valid
+            (r"'\u{d799}'"      => Literal(Character, "\u{D799}")),
+            (r" "               => Whitespace),
+            (r"'\u{D800}'"      => Literal(Character, "\u{FFFD}")),
+            (r" "               => Whitespace),
+            (r"'\u{DEAD}'"      => Literal(Character, "\u{FFFD}")),
+            (r" "               => Whitespace),
+            (r"'\u{DFfF}'"      => Literal(Character, "\u{FFFD}")),
+            (r" "               => Whitespace),
+            (r"'\u{e000}'"      => Literal(Character, "\u{E000}")),
+            (r" "               => Whitespace),
+            // Non-characters are okay
+            (r"'\u{FFFE}'"      => Literal(Character, "\u{FFFE}")),
+            (r" "               => Whitespace),
+            (r"'\u{fffff}'"     => Literal(Character, "\u{FFFFF}")),
+            (r" "               => Whitespace),
+            // Private use area is okay
+            (r"'\u{F0123}'"     => Literal(Character, "\u{F0123}")),
+            (r" "               => Whitespace),
+            (r"'\u{0}'"         => Literal(Character, "\u{0}")),
+            (r" "               => Whitespace),
+            (r"'\u{00000005}'"  => Literal(Character, "\u{5}")),
+            (r" "               => Whitespace),
+            // Out of range are not okay but they are still scanned over fine
+            (r"'\u{99999999}'"  => Literal(Character, "\u{FFFD}")),
+            (r" "               => Whitespace),
+            (r"'\u{f0f0f0deadbeef00012345}'" => Literal(Character, "\u{FFFD}"));
+
+        Severity::Error:
+            ( 22 , 26), ( 49 , 57), (60, 68), (71, 79), (151, 163), (166, 192);
+        }
     }
 
     // We adopt a simple heuristic for the case of missing closing quotes in character literals.
@@ -2560,90 +2728,101 @@ mod tests {
 
     #[test]
     fn character_multicharacter_literals() {
-        check(&[
-            ScannerTestSlice("'ab'",                Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",                   Token::Whitespace),
-            ScannerTestSlice("'\u{00E6}\u{0113}'",  Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",                   Token::Whitespace),
-            ScannerTestSlice(r"'\x31\x32'",         Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",                   Token::Whitespace),
-            ScannerTestSlice(r"'\u{123}\u{4567}'",  Token::Literal(Lit::Character)),
-        ], &[ Span::new(0, 4), Span::new(5, 11), Span::new(12, 22), Span::new(23, 40) ], &[]);
+        check! {
+            ("'ab'"                 => Literal(Character, "\u{FFFD}")),
+            (" "                    => Whitespace),
+            ("'\u{00E6}\u{0113}'"   => Literal(Character, "\u{FFFD}")),
+            (" "                    => Whitespace),
+            (r"'\x31\x32'"          => Literal(Character, "\u{FFFD}")),
+            (" "                    => Whitespace),
+            (r"'\u{123}\u{4567}'"   => Literal(Character, "\u{FFFD}"));
+
+        Severity::Error:
+            (0, 4), (5, 11), (12, 22), (23, 40);
+        }
     }
 
     #[test]
     fn character_missing_quotes() {
-        check(&[
-            ScannerTestSlice("'ab some + thing", Token::Unrecognized),
-            ScannerTestSlice("\n",               Token::Whitespace),
-            ScannerTestSlice("'''",              Token::Literal(Lit::Character)),
-            ScannerTestSlice("', more",          Token::Unrecognized),
-            ScannerTestSlice("\r\n",             Token::Whitespace),
-            ScannerTestSlice("''",               Token::Literal(Lit::Character)), // special case
-            ScannerTestSlice(",",                Token::Comma),
-            ScannerTestSlice(" ",                Token::Whitespace),
-            ScannerTestSlice(".",                Token::Dot),
-            ScannerTestSlice("'test\rline'",     Token::Literal(Lit::Character)),
-            ScannerTestSlice("'another\rtest",   Token::Unrecognized),
-        ], &[
-            Span::new(29, 31), Span::new(39, 40), Span::new(34, 45), Span::new(53, 54),
-        ], &[
-            Span::new( 0, 16), Span::new(20, 27), Span::new(45, 58),
-        ]);
+        check! {
+            ("'ab some + thing"     => Unrecognized),
+            ("\n"                   => Whitespace),
+            ("'''"                  => Literal(Character, "'")),
+            ("', more"              => Unrecognized),
+            ("\r\n"                 => Whitespace),
+            // special case
+            ("''"                   => Literal(Character, "\u{FFFD}")),
+            (","                    => Comma),
+            (" "                    => Whitespace),
+            ("."                    => Dot),
+            ("'test\rline'"         => Literal(Character, "\u{FFFD}")),
+            ("'another\rtest"       => Unrecognized);
+
+        Severity::Error:
+            (29, 31), (39, 40), (34, 45), (53, 54);
+
+        Severity::Fatal:
+            ( 0, 16), (20, 27), (45, 58);
+        }
     }
 
     #[test]
     fn character_premature_termination() {
-        check(&[ ScannerTestSlice("'",      Token::Unrecognized) ], &[], &[ Span::new(0, 1) ]);
-        check(&[ ScannerTestSlice("'a",     Token::Unrecognized) ], &[], &[ Span::new(0, 2) ]);
-        check(&[ ScannerTestSlice("'\\",    Token::Unrecognized) ], &[], &[ Span::new(0, 2) ]);
-        check(&[ ScannerTestSlice("'\t",    Token::Unrecognized) ], &[], &[ Span::new(0, 2) ]);
-        check(&[ ScannerTestSlice("'\\x",   Token::Unrecognized) ], &[ Span::new(1, 3) ],
-                                                                    &[ Span::new(0, 3) ]);
-        check(&[ ScannerTestSlice("'\\y",   Token::Unrecognized) ], &[ Span::new(1, 3) ],
-                                                                    &[ Span::new(0, 3) ]);
-        check(&[ ScannerTestSlice("'\\u",   Token::Unrecognized) ], &[ Span::new(3, 3) ],
-                                                                    &[ Span::new(0, 3) ]);
-        check(&[ ScannerTestSlice("'\\u{",  Token::Unrecognized) ], &[ Span::new(3, 4) ],
-                                                                    &[ Span::new(0, 4) ]);
-        check(&[ ScannerTestSlice("'\\u{}", Token::Unrecognized) ], &[ Span::new(3, 5) ],
-                                                                    &[ Span::new(0, 5) ]);
+        check! { ("'"      => Unrecognized); Severity::Fatal: (0, 1); }
+        check! { ("'a"     => Unrecognized); Severity::Fatal: (0, 2); }
+        check! { ("'\\"    => Unrecognized); Severity::Fatal: (0, 2); }
+        check! { ("'\t"    => Unrecognized); Severity::Fatal: (0, 2); }
+        check! { ("'\\x"   => Unrecognized); Severity::Error: (1, 3);
+                                             Severity::Fatal: (0, 3); }
+        check! { ("'\\y"   => Unrecognized); Severity::Error: (1, 3);
+                                             Severity::Fatal: (0, 3); }
+        check! { ("'\\u"   => Unrecognized); Severity::Error: (3, 3);
+                                             Severity::Fatal: (0, 3); }
+        check! { ("'\\u{"  => Unrecognized); Severity::Error: (3, 4);
+                                             Severity::Fatal: (0, 4); }
+        check! { ("'\\u{}" => Unrecognized); Severity::Error: (3, 5);
+                                             Severity::Fatal: (0, 5); }
     }
 
     #[test]
     fn character_bare_crs_and_line_endings() {
-        check(&[
+        check! {
             // Bare carrige returns are reported as misplaced restricted characters
-            ScannerTestSlice("'\r'",         Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",            Token::Whitespace),
-            ScannerTestSlice("'Carr\riage'", Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",            Token::Whitespace),
+            ("'\r'"         => Literal(Character, "\r")),
+            (" "            => Whitespace),
+            ("'Carr\riage'" => Literal(Character, "\u{FFFD}")),
+            (" "            => Whitespace),
             // But proper line endings are treated as markers of missing closing quotes
-            ScannerTestSlice("'",            Token::Unrecognized),
-            ScannerTestSlice("\n",           Token::Whitespace),
-            ScannerTestSlice("' '",          Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",            Token::Whitespace),
-            ScannerTestSlice("'",            Token::Unrecognized),
-            ScannerTestSlice("\r\n",         Token::Whitespace),
-            ScannerTestSlice("'",            Token::Unrecognized),
-        ], &[
-            Span::new( 1,  2), Span::new( 9, 10), Span::new( 4, 15),
-        ], &[
-            Span::new(16, 17), Span::new(22, 23), Span::new(25, 26)
-        ]);
+            ("'"            => Unrecognized),
+            ("\n"           => Whitespace),
+            ("' '"          => Literal(Character, " ")),
+            (" "            => Whitespace),
+            ("'"            => Unrecognized),
+            ("\r\n"         => Whitespace),
+            ("'"            => Unrecognized);
+
+        Severity::Error:
+            ( 1,  2), ( 9, 10), ( 4, 15);
+
+        Severity::Fatal:
+            (16, 17), (22, 23), (25, 26);
+        }
     }
 
     #[test]
     fn character_incorrect_unicode_escape_length() {
-        check(&[
-            ScannerTestSlice(r"'\x'",      Token::Literal(Lit::Character)),
-            ScannerTestSlice(r" ",         Token::Whitespace),
-            ScannerTestSlice(r"'\x1'",     Token::Literal(Lit::Character)),
-            ScannerTestSlice(r" ",         Token::Whitespace),
-            ScannerTestSlice(r"'\x123'",   Token::Literal(Lit::Character)),
-            ScannerTestSlice(r" ",         Token::Whitespace),
-            ScannerTestSlice(r"'\u{}'",    Token::Literal(Lit::Character)),
-        ], &[ Span::new(1, 3), Span::new(6, 9), Span::new(12, 17), Span::new(22, 24) ], &[]);
+        check! {
+            (r"'\x'"        => Literal(Character, "\u{FFFD}")),
+            (r" "           => Whitespace),
+            (r"'\x1'"       => Literal(Character, "\u{FFFD}")),
+            (r" "           => Whitespace),
+            (r"'\x123'"     => Literal(Character, "\u{FFFD}")),
+            (r" "           => Whitespace),
+            (r"'\u{}'"      => Literal(Character, "\u{FFFD}"));
+
+        Severity::Error:
+            (1, 3), (6, 9), (12, 17), (22, 24);
+        }
     }
 
     // A similar heuristic is used for missing curly braces.
@@ -2655,200 +2834,204 @@ mod tests {
 
     #[test]
     fn character_incorrect_unicode_braces() {
-        check(&[
-            ScannerTestSlice(r"'\u{123'",               Token::Literal(Lit::Character)),
-            ScannerTestSlice(r" ",                      Token::Whitespace),
-            ScannerTestSlice(r"'\u{'",                  Token::Literal(Lit::Character)),
-            ScannerTestSlice(r" ",                      Token::Whitespace),
-            ScannerTestSlice(r"'\u{uiui}'",             Token::Literal(Lit::Character)),
-            ScannerTestSlice(r" ",                      Token::Whitespace),
-            ScannerTestSlice(r"'\u{uiui'",              Token::Literal(Lit::Character)),
-            ScannerTestSlice(r" ",                      Token::Whitespace),
-            ScannerTestSlice(r"'\u{some long string}'", Token::Literal(Lit::Character)),
-            ScannerTestSlice(r" ",                      Token::Whitespace),
-            ScannerTestSlice(r"'\u{some long string'",  Token::Literal(Lit::Character)),
-            ScannerTestSlice(r" ",                      Token::Whitespace),
-            ScannerTestSlice(r"'\u{123, missing",       Token::Unrecognized),
-            ScannerTestSlice("\n",                      Token::Whitespace),
-            ScannerTestSlice(r"'\u{more missing",       Token::Unrecognized),
-        ], &[
-            Span::new(  7,   7), Span::new( 12,  13), Span::new( 16,  24), Span::new( 34,  34),
-            Span::new( 27,  34), Span::new( 37,  57), Span::new( 79,  79), Span::new( 60,  79),
-            Span::new( 97,  97), Span::new( 82,  97), Span::new(114, 114), Span::new( 99, 114),
-        ], &[
-            Span::new( 81,  97), Span::new( 98, 114),
-        ]);
+        check! {
+            (r"'\u{123'"                => Literal(Character, "\u{123}")),
+            (r" "                       => Whitespace),
+            (r"'\u{'"                   => Literal(Character, "\u{FFFD}")),
+            (r" "                       => Whitespace),
+            (r"'\u{uiui}'"              => Literal(Character, "\u{FFFD}")),
+            (r" "                       => Whitespace),
+            (r"'\u{uiui'"               => Literal(Character, "\u{FFFD}")),
+            (r" "                       => Whitespace),
+            (r"'\u{some long string}'"  => Literal(Character, "\u{FFFD}")),
+            (r" "                       => Whitespace),
+            (r"'\u{some long string'"   => Literal(Character, "\u{FFFD}")),
+            (r" "                       => Whitespace),
+            (r"'\u{123, missing"        => Unrecognized),
+            ("\n"                       => Whitespace),
+            (r"'\u{more missing"        => Unrecognized);
+
+        Severity::Error:
+            (  7,   7), ( 12,  13), ( 16,  24), ( 34,  34), ( 27,  34), ( 37,  57), ( 79,  79),
+            ( 60,  79), ( 97,  97), ( 82,  97), (114, 114), ( 99, 114);
+
+        Severity::Fatal:
+            ( 81,  97), ( 98, 114);
+        }
     }
 
     #[test]
     fn character_unicode_missing_digits() {
-        check(&[
-            ScannerTestSlice(r"'\u'",       Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice(r"'\u}'",      Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice(r"'\uguu~'",   Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice(r"'\ux\uy'",   Token::Literal(Lit::Character)),
-        ], &[ Span::new( 3,  3), Span::new( 8,  9), Span::new(14, 14), Span::new(11, 19),
-              Span::new(23, 23), Span::new(26, 26), Span::new(20, 28),
-        ], &[]);
+        check! {
+            (r"'\u'"        => Literal(Character, "\u{FFFD}")),
+            (" "            => Whitespace),
+            (r"'\u}'"       => Literal(Character, "\u{FFFD}")),
+            (" "            => Whitespace),
+            (r"'\uguu~'"    => Literal(Character, "\u{FFFD}")),
+            (" "            => Whitespace),
+            (r"'\ux\uy'"    => Literal(Character, "\u{FFFD}"));
+
+        Severity::Error:
+            ( 3,  3), ( 8,  9), (14, 14), (11, 19), (23, 23), (26, 26), (20, 28);
+        }
     }
 
     #[test]
     fn character_unicode_bare_digits() {
-        check(&[
-            ScannerTestSlice(r"'\u0000'",       Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",               Token::Whitespace),
-            ScannerTestSlice(r"'\u9'",          Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",               Token::Whitespace),
-            ScannerTestSlice(r"'\uDEAD'",       Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",               Token::Whitespace),
-            ScannerTestSlice(r"'\u10F0F0'",     Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",               Token::Whitespace),
-            ScannerTestSlice(r"'\u9999999999'", Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",               Token::Whitespace),
-            ScannerTestSlice(r"'\u1\u2'",       Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",               Token::Whitespace),
-        ], &[ Span::new( 3,  7), Span::new(12, 13), Span::new(18, 22), Span::new(16, 22),
-              Span::new(27, 33), Span::new(38, 48), Span::new(36, 48), Span::new(53, 54),
-              Span::new(56, 57), Span::new(50, 58),
-        ], &[]);
+        check! {
+            (r"'\u0000'"        => Literal(Character, "\u{0}")),
+            (" "                => Whitespace),
+            (r"'\u9'"           => Literal(Character, "\u{9}")),
+            (" "                => Whitespace),
+            (r"'\uDEAD'"        => Literal(Character, "\u{FFFD}")),
+            (" "                => Whitespace),
+            (r"'\u10F0F0'"      => Literal(Character, "\u{10F0F0}")),
+            (" "                => Whitespace),
+            (r"'\u9999999999'"  => Literal(Character, "\u{FFFD}")),
+            (" "                => Whitespace),
+            (r"'\u1\u2'"        => Literal(Character, "\u{FFFD}")),
+            (" "                => Whitespace);
+
+        Severity::Error:
+            ( 3,  7), (12, 13), (18, 22), (16, 22), (27, 33), (38, 48), (36, 48), (53, 54),
+            (56, 57), (50, 58);
+        }
     }
 
     #[test]
     fn character_unknown_escapes() {
-        check(&[
+        check! {
             // Unsupported C escapes
-            ScannerTestSlice(r"'\a'",       Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice(r"'\b'",       Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice(r"'\f'",       Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice(r"'\v'",       Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice(r"'\?'",       Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",           Token::Whitespace),
+            (r"'\a'"        => Literal(Character, "a")),
+            (" "            => Whitespace),
+            (r"'\b'"        => Literal(Character, "b")),
+            (" "            => Whitespace),
+            (r"'\f'"        => Literal(Character, "f")),
+            (" "            => Whitespace),
+            (r"'\v'"        => Literal(Character, "v")),
+            (" "            => Whitespace),
+            (r"'\?'"        => Literal(Character, "?")),
+            (" "            => Whitespace),
 
             // Unsupported hell-knows-whats
-            ScannerTestSlice(r"'\X9'",      Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice(r"'\@'",       Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice("'\\\u{0430}'", Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice(r"'\m\'",      Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",           Token::Whitespace),
+            (r"'\X9'"       => Literal(Character, "\u{FFFD}")),
+            (" "            => Whitespace),
+            (r"'\@'"        => Literal(Character, "@")),
+            (" "            => Whitespace),
+            ("'\\\u{0430}'" => Literal(Character, "\u{0430}")),
+            (" "            => Whitespace),
+            (r"'\m\'"       => Literal(Character, "\u{FFFD}")),
+            (" "            => Whitespace),
 
             // Attempts at line-continuation
-            ScannerTestSlice("'\\",         Token::Unrecognized),
-            ScannerTestSlice("\n",          Token::Whitespace),
-            ScannerTestSlice("' '",         Token::Literal(Lit::Character)),
-            ScannerTestSlice("  ",          Token::Whitespace),
-            ScannerTestSlice("'\\\r'",      Token::Literal(Lit::Character)),
-            ScannerTestSlice("  ",          Token::Whitespace),
-            ScannerTestSlice("'foo\\",      Token::Unrecognized),
-            ScannerTestSlice("\r\n",        Token::Whitespace),
-            ScannerTestSlice("' '",         Token::Literal(Lit::Character)),
-            ScannerTestSlice("  ",          Token::Whitespace),
-            ScannerTestSlice("'b\\\t\\",    Token::Unrecognized),
-            ScannerTestSlice("\n\t",          Token::Whitespace),
-            ScannerTestSlice("'",           Token::Unrecognized),
-        ], &[
-            Span::new( 1,  3), Span::new( 6,  8), Span::new(11, 13), Span::new(16, 18),
-            Span::new(21, 23), Span::new(26, 28), Span::new(25, 30), Span::new(32, 34),
-            Span::new(37, 40), Span::new(43, 45), Span::new(42, 47), Span::new(58, 59),
-            Span::new(57, 59), Span::new(76, 78),
-        ], &[
-            Span::new(48, 50), Span::new(62, 67), Span::new(74, 79), Span::new(81, 82),
-        ]);
+            ("'\\"          => Unrecognized),
+            ("\n"           => Whitespace),
+            ("' '"          => Literal(Character, " ")),
+            ("  "           => Whitespace),
+            ("'\\\r'"       => Literal(Character, "\r")),
+            ("  "           => Whitespace),
+            ("'foo\\"       => Unrecognized),
+            ("\r\n"         => Whitespace),
+            ("' '"          => Literal(Character, " ")),
+            ("  "           => Whitespace),
+            ("'b\\\t\\"     => Unrecognized),
+            ("\n\t"         => Whitespace),
+            ("'"            => Unrecognized);
+
+        Severity::Error:
+            ( 1,  3), ( 6,  8), (11, 13), (16, 18), (21, 23), (26, 28), (25, 30), (32, 34),
+            (37, 40), (43, 45), (42, 47), (58, 59), (57, 59), (76, 78);
+
+        Severity::Fatal:
+            (48, 50), (62, 67), (74, 79), (81, 82);
+        }
     }
 
     #[test]
     fn character_type_suffixes() {
-        check(&[
+        check! {
             // Suffixes are words
-            ScannerTestSlice("'x'wide",                 Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("'\t'ASCII",               Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("'\\t'ASCII",              Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("'\u{3435}'_",             Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
+            ("'x'wide"                      => Literal(Character, "x", "wide")),
+            (" "                            => Whitespace),
+            ("'\t'ASCII"                    => Literal(Character, "\t", "ASCII")),
+            (" "                            => Whitespace),
+            ("'\\t'ASCII"                   => Literal(Character, "\t", "ASCII")),
+            (" "                            => Whitespace),
+            ("'\u{3435}'_"                  => Literal(Character, "\u{3435}", "_")),
+            (" "                            => Whitespace),
             // And only words, symbols are not suffixes
-            ScannerTestSlice("'='",                     Token::Literal(Lit::Character)),
-            ScannerTestSlice("=",                       Token::Identifier),
-            ScannerTestSlice("'='",                     Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
+            ("'='"                          => Literal(Character, "=")),
+            ("="                            => Identifier("=")),
+            ("'='"                          => Literal(Character, "=")),
+            (" "                            => Whitespace),
             // Unicode suffixes
-            ScannerTestSlice("'\u{1F74}'\u{1F74}",      Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("'\\u{1F74}'\\u{1F74}",    Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-        ], &[], &[]);
+            ("'\u{1F74}'\u{1F74}"           => Literal(Character, "\u{1F74}", "\u{1F74}")),
+            (" "                            => Whitespace),
+            ("'\\u{1F74}'\\u{1F74}"         => Literal(Character, "\u{1F74}", "\u{1F74}")),
+            (" "                            => Whitespace);
+        }
     }
 
     #[test]
     fn character_type_suffixes_invalid() {
-        check(&[
+        check! {
             // Inner invalid characters are treated as constituents of suffixes,
             // just as in regular identifiers.
-            ScannerTestSlice("'\\u{EEEE}'\\u{47f}\\u{DAAA}",    Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",                               Token::Whitespace),
-            ScannerTestSlice("'\\u{EEEE}'b\\u6Fx",              Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",                               Token::Whitespace),
+            ("'\\u{EEEE}'\\u{47f}\\u{DAAA}" => Literal(Character, "\u{EEEE}", "\u{047F}\u{FFFD}")),
+            (" "                            => Whitespace),
+            ("'\\u{EEEE}'b\\u6Fx"           => Literal(Character, "\u{EEEE}", "b\u{FFFD}x")),
+            (" "                            => Whitespace),
             // However, if a literal is immediately followed by an invalid characters
             // they are not scanned over in anticipation of suffix. They are instantly
             // treated as Token::Unrecognized following the literal
-            ScannerTestSlice("'0'",                     Token::Literal(Lit::Character)),
-            ScannerTestSlice("\\u0\\u1",                Token::Unrecognized),
-            ScannerTestSlice("\t",                      Token::Whitespace),
-            ScannerTestSlice("'\\u{F000}'",             Token::Literal(Lit::Character)),
-            ScannerTestSlice("\\u{F000}",               Token::Unrecognized),
-            ScannerTestSlice("\t",                      Token::Whitespace),
-            ScannerTestSlice("'f'",                     Token::Literal(Lit::Character)),
-            ScannerTestSlice("\\",                      Token::Unrecognized),
-            ScannerTestSlice("x",                       Token::Identifier),
-        ], &[
-            Span::new(17, 25), Span::new(39, 41), Span::new(37, 41), Span::new(48, 49),
-            Span::new(51, 52), Span::new(46, 52), Span::new(63, 71), Span::new(75, 76),
-        ], &[]);
+            ("'0'"                          => Literal(Character, "0")),
+            ("\\u0\\u1"                     => Unrecognized),
+            ("\t"                           => Whitespace),
+            ("'\\u{F000}'"                  => Literal(Character, "\u{F000}")),
+            ("\\u{F000}"                    => Unrecognized),
+            ("\t"                           => Whitespace),
+            ("'f'"                          => Literal(Character, "f")),
+            ("\\"                           => Unrecognized),
+            ("x"                            => Identifier("x"));
+
+        Severity::Error:
+            (17, 25), (39, 41), (37, 41), (48, 49), (51, 52), (46, 52), (63, 71), (75, 76);
+        }
     }
 
     #[test]
     fn character_type_suffixes_after_invalid() {
-        check(&[
+        check! {
             // Type suffixes are scanned over just fine after invalid characters
-            ScannerTestSlice("'\\u{DADA}'u32",          Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("''cc",                    Token::Literal(Lit::Character)),
-            ScannerTestSlice("''",                      Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("'\\u0'_\\u0",             Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("'\\5'q",                  Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("'\r'foo",                 Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("'some'suffix",            Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
+            ("'\\u{DADA}'u32"               => Literal(Character, "\u{FFFD}", "u32")),
+            (" "                            => Whitespace),
+            ("''cc"                         => Literal(Character, "\u{FFFD}", "cc")),
+            ("''"                           => Literal(Character, "\u{FFFD}")),
+            (" "                            => Whitespace),
+            ("'\\u0'_\\u0"                  => Literal(Character, "\u{0}", "_\u{FFFD}")),
+            (" "                            => Whitespace),
+            ("'\\5'q"                       => Literal(Character, "5", "q")),
+            (" "                            => Whitespace),
+            ("'\r'foo"                      => Literal(Character, "\r", "foo")),
+            (" "                            => Whitespace),
+            ("'some'suffix"                 => Literal(Character, "\u{FFFD}", "suffix")),
+            (" "                            => Whitespace),
             // But missing quotes are something else
-            ScannerTestSlice("'foo",                    Token::Unrecognized),
-            ScannerTestSlice("\n",                      Token::Whitespace),
-            ScannerTestSlice("c32",                     Token::Identifier),
-            ScannerTestSlice("\t",                      Token::Whitespace),
-            ScannerTestSlice("'bar",                    Token::Unrecognized),
-            ScannerTestSlice("\r\n",                    Token::Whitespace),
-            ScannerTestSlice("'baz",                    Token::Unrecognized),
-        ], &[
-            Span::new(  1,  9), Span::new( 14, 16), Span::new( 18, 20), Span::new( 24, 25),
-            Span::new( 29, 30), Span::new( 27, 30), Span::new( 32, 34), Span::new( 38, 39),
-            Span::new( 44, 50),
-        ], &[
-            Span::new( 57, 61), Span::new( 66, 70), Span::new( 72, 76),
-        ]);
+            ("'foo"                         => Unrecognized),
+            ("\n"                           => Whitespace),
+            ("c32"                          => Identifier("c32")),
+            ("\t"                           => Whitespace),
+            ("'bar"                         => Unrecognized),
+            ("\r\n"                         => Whitespace),
+            ("'baz"                         => Unrecognized);
+
+        Severity::Error:
+            (  1,  9), ( 14, 16), ( 18, 20), ( 24, 25), ( 29, 30), ( 27, 30), ( 32, 34),
+            ( 38, 39), ( 44, 50);
+
+        Severity::Fatal:
+            ( 57, 61), ( 66, 70), ( 72, 76);
+        }
     }
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2856,258 +3039,271 @@ mod tests {
 
     #[test]
     fn string_basic() {
-        check(&[
-            ScannerTestSlice(r#""""#,    Token::Literal(Lit::String)),
-            ScannerTestSlice(" ",        Token::Whitespace),
-            ScannerTestSlice(r#"'"'"#,   Token::Literal(Lit::Character)),
-            ScannerTestSlice(r#""'""#,   Token::Literal(Lit::String)),
-            ScannerTestSlice(" ",        Token::Whitespace),
-            ScannerTestSlice(r#""foo""#, Token::Literal(Lit::String)),
-            ScannerTestSlice(r#""bar""#, Token::Literal(Lit::String)),
-            ScannerTestSlice(" ",        Token::Whitespace),
-            ScannerTestSlice(r#""`!@#$%^&*()_+:<>?';[]{}=""#, Token::Literal(Lit::String)),
-        ], &[], &[]);
+        check! {
+            (r#""""#                            => Literal(String, "")),
+            (" "                                => Whitespace),
+            (r#"'"'"#                           => Literal(Character, "\"")),
+            (r#""'""#                           => Literal(String, "'")),
+            (" "                                => Whitespace),
+            (r#""foo""#                         => Literal(String, "foo")),
+            (r#""bar""#                         => Literal(String, "bar")),
+            (" "                                => Whitespace),
+            (r#""`!@#$%^&*()_+:<>?';[]{}=""#    => Literal(String, "`!@#$%^&*()_+:<>?';[]{}="));
+        }
     }
 
     #[test]
     fn string_unicode() {
-        check(&[
-            ScannerTestSlice("\"\u{0395}\u{03C9}\u{03C2}\u{03BD}\u{03B5}\"",        Token::Literal(Lit::String)),
-            ScannerTestSlice(" ",                                               Token::Whitespace),
-            ScannerTestSlice("\"\u{041A}\u{044E}\u{043C}\u{043A}\u{0443}\"",        Token::Literal(Lit::String)),
-            ScannerTestSlice(" ",                                               Token::Whitespace),
-            ScannerTestSlice("\"\u{4EE3}\u{3072}\u{5099}\u{9752}\u{8CBB}\"",        Token::Literal(Lit::String)),
-            ScannerTestSlice(" ",                                               Token::Whitespace),
-            ScannerTestSlice("\"\u{0627}\u{0644}\u{062D}\u{0643}\u{0648}\u{0645}\"",Token::Literal(Lit::String)),
-            ScannerTestSlice(" ",                                               Token::Whitespace),
-            ScannerTestSlice("\"\u{100100}\u{100200}\u{103000}\u{10FEEE}\u{FEFF}\"",Token::Literal(Lit::String)),
-        ], &[], &[]);
+        check! {
+            ("\"\u{0395}\u{03C9}\u{03C2}\u{03BD}\u{03B5}\""         => Literal(String, "\u{0395}\u{03C9}\u{03C2}\u{03BD}\u{03B5}")),
+            (" "                                                    => Whitespace),
+            ("\"\u{041A}\u{044E}\u{043C}\u{043A}\u{0443}\""         => Literal(String, "\u{041A}\u{044E}\u{043C}\u{043A}\u{0443}")),
+            (" "                                                    => Whitespace),
+            ("\"\u{4EE3}\u{3072}\u{5099}\u{9752}\u{8CBB}\""         => Literal(String, "\u{4EE3}\u{3072}\u{5099}\u{9752}\u{8CBB}")),
+            (" "                                                    => Whitespace),
+            ("\"\u{0627}\u{0644}\u{062D}\u{0643}\u{0648}\u{0645}\"" => Literal(String, "\u{0627}\u{0644}\u{062D}\u{0643}\u{0648}\u{0645}")),
+            (" "                                                    => Whitespace),
+            ("\"\u{100100}\u{100200}\u{103000}\u{10FEEE}\u{FEFF}\"" => Literal(String, "\u{100100}\u{100200}\u{103000}\u{10FEEE}\u{FEFF}"));
+        }
     }
 
     #[test]
     fn string_escapes() {
-        check(&[
+        check! {
             // C-style escapes supported by characters
-            ScannerTestSlice(r#""\0\t\r\n""#,    Token::Literal(Lit::String)),
+            (r#""\0\t\r\n""#    => Literal(String, "\0\t\r\n")),
             // Double quotes and backslashes must be escaped in strings
-            ScannerTestSlice(r#""\\\" \"\\\"""#, Token::Literal(Lit::String)),
+            (r#""\\\" \"\\\"""# => Literal(String, "\\\" \"\\\"")),
             // Nulls and tabs can be used unescaped
-            ScannerTestSlice("\"\t\0\t \tx\0\"", Token::Literal(Lit::String)),
-        ], &[], &[]);
+            ("\"\t\0\t \tx\0\"" => Literal(String, "\t\0\t \tx\0"));
+        }
     }
 
     #[test]
     fn string_unicode_escapes() {
-        check(&[
+        check! {
             // Strings support both byte escapes...
-            ScannerTestSlice(r#""\x00\x3D\x70 \x50\x6E""#,   Token::Literal(Lit::String)),
+            (r#""\x00\x3D\x70 \x50\x6E""#       => Literal(String, "\x00\x3D\x70 \x50\x6E")),
             // ...and Unicode escapes...
-            ScannerTestSlice(r#""\u{3} \u{12F1E}\u{F0F0}""#, Token::Literal(Lit::String)),
+            (r#""\u{3} \u{12F1E}\u{F0F0}""#     => Literal(String, "\u{3} \u{12F1E}\u{F0F0}")),
             // ...and, as with characters, somewhat care about their semantics.
-            ScannerTestSlice(r#""\xFF\xFE\x00\xDE\xAD""#,    Token::Literal(Lit::String)),
-            ScannerTestSlice(r#""\u{D900}\u{F0F0F090909}""#, Token::Literal(Lit::String)),
-        ], &[ Span::new(49, 53), Span::new(53, 57), Span::new(61, 65), Span::new(65, 69),
-              Span::new(71, 79), Span::new(79, 94) ], &[]);
+            (r#""\xFF\xFE\x00\xDE\xAD""#        => Literal(String, "\u{FFFD}\u{FFFD}\x00\u{FFFD}\u{FFFD}")),
+            (r#""\u{D900}\u{F0F0F090909}""#     => Literal(String, "\u{FFFD}\u{FFFD}"));
+
+        Severity::Error:
+            (49, 53), (53, 57), (61, 65), (65, 69), (71, 79), (79, 94);
+        }
     }
 
     #[test]
     fn string_multiline() {
-        check(&[
-            ScannerTestSlice("\"multiline\ndemo\"",            Token::Literal(Lit::String)),
-            ScannerTestSlice("\n",                             Token::Whitespace),
-            ScannerTestSlice("\"windows\r\nline\r\nendings\"", Token::Literal(Lit::String)),
-            ScannerTestSlice("\n",                             Token::Whitespace),
-            ScannerTestSlice("\"bare\rCR character\"",         Token::Literal(Lit::String)),
-            ScannerTestSlice("\n",                             Token::Whitespace),
-            ScannerTestSlice("\"continuation\\\nstring\"",     Token::Literal(Lit::String)),
-            ScannerTestSlice("\n",                             Token::Whitespace),
-            ScannerTestSlice("\"windows\\\r\ncontinuation\"",  Token::Literal(Lit::String)),
-            ScannerTestSlice("\n",                             Token::Whitespace),
-            ScannerTestSlice("\"cont\\\n\t\t  with space\"",   Token::Literal(Lit::String)),
-            ScannerTestSlice("\n",                             Token::Whitespace),
-            ScannerTestSlice("\"\\\r\n\none more time\"",      Token::Literal(Lit::String)),
-            ScannerTestSlice("\n",                             Token::Whitespace),
-            ScannerTestSlice("\"but\\\rbare CR doesn't work\"", Token::Literal(Lit::String)),
-        ], &[ Span::new(47, 48), Span::new(158, 159), Span::new(157, 159) ], &[]);
+        check! {
+            ("\"multiline\ndemo\""              => Literal(String, "multiline\ndemo")),
+            ("\n"                               => Whitespace),
+            ("\"windows\r\nline\r\nendings\""   => Literal(String, "windows\nline\nendings")),
+            ("\n"                               => Whitespace),
+            ("\"bare\rCR character\""           => Literal(String, "bare\rCR character")),
+            ("\n"                               => Whitespace),
+            ("\"continuation\\\nstring\""       => Literal(String, "continuationstring")),
+            ("\n"                               => Whitespace),
+            ("\"windows\\\r\ncontinuation\""    => Literal(String, "windowscontinuation")),
+            ("\n"                               => Whitespace),
+            ("\"cont\\\n\t\t  with space\""     => Literal(String, "contwith space")),
+            ("\n"                               => Whitespace),
+            ("\"\\\r\n\none more time\""        => Literal(String, "one more time")),
+            ("\n"                               => Whitespace),
+            ("\"but\\\rbare CR doesn't work\""  => Literal(String, "but\rbare CR doesn't work"));
+
+        Severity::Error:
+            (47, 48), (158, 159), (157, 159);
+        }
     }
 
     #[test]
     fn string_premature_termination() {
-        check(&[ ScannerTestSlice("\"",      Token::Unrecognized) ], &[], &[ Span::new(0, 1) ]);
-        check(&[ ScannerTestSlice("\"a",     Token::Unrecognized) ], &[], &[ Span::new(0, 2) ]);
-        check(&[ ScannerTestSlice("\"\\",    Token::Unrecognized) ], &[], &[ Span::new(0, 2) ]);
-        check(&[ ScannerTestSlice("\"\t",    Token::Unrecognized) ], &[], &[ Span::new(0, 2) ]);
-        check(&[ ScannerTestSlice("\"\\x",   Token::Unrecognized) ], &[ Span::new(1, 3) ],
-                                                                     &[ Span::new(0, 3) ]);
-        check(&[ ScannerTestSlice("\"\\y",   Token::Unrecognized) ], &[ Span::new(1, 3) ],
-                                                                     &[ Span::new(0, 3) ]);
-        check(&[ ScannerTestSlice("\"\\u",   Token::Unrecognized) ], &[ Span::new(3, 3) ],
-                                                                     &[ Span::new(0, 3) ]);
-        check(&[ ScannerTestSlice("\"\\u{",  Token::Unrecognized) ], &[ Span::new(3, 4) ],
-                                                                     &[ Span::new(0, 4) ]);
-        check(&[ ScannerTestSlice("\"\\u{}", Token::Unrecognized) ], &[ Span::new(3, 5) ],
-                                                                     &[ Span::new(0, 5) ]);
+        check! { ("\""      => Unrecognized); Severity::Fatal: (0, 1); }
+        check! { ("\"a"     => Unrecognized); Severity::Fatal: (0, 2); }
+        check! { ("\"\\"    => Unrecognized); Severity::Fatal: (0, 2); }
+        check! { ("\"\t"    => Unrecognized); Severity::Fatal: (0, 2); }
+        check! { ("\"\\x"   => Unrecognized); Severity::Error: (1, 3);
+                                              Severity::Fatal: (0, 3); }
+        check! { ("\"\\y"   => Unrecognized); Severity::Error: (1, 3);
+                                              Severity::Fatal: (0, 3); }
+        check! { ("\"\\u"   => Unrecognized); Severity::Error: (3, 3);
+                                              Severity::Fatal: (0, 3); }
+        check! { ("\"\\u{"  => Unrecognized); Severity::Error: (3, 4);
+                                              Severity::Fatal: (0, 4); }
+        check! { ("\"\\u{}" => Unrecognized); Severity::Error: (3, 5);
+                                              Severity::Fatal: (0, 5); }
     }
 
     #[test]
     fn string_incorrect_unicode_escape_length() {
-        check(&[
-            ScannerTestSlice(r#""\x""#,    Token::Literal(Lit::String)),
-            ScannerTestSlice(r#" "#,       Token::Whitespace),
-            ScannerTestSlice(r#""\x1""#,   Token::Literal(Lit::String)),
-            ScannerTestSlice(r#" "#,       Token::Whitespace),
-            ScannerTestSlice(r#""\x123""#, Token::Literal(Lit::String)),
-            ScannerTestSlice(r#" "#,       Token::Whitespace),
-            ScannerTestSlice(r#""\u{}""#,  Token::Literal(Lit::String)),
-        ], &[ Span::new(1, 3), Span::new(6, 9), Span::new(12, 17), Span::new(22, 24) ], &[]);
+        check! {
+            (r#""\x""#     => Literal(String, "\u{FFFD}")),
+            (r#" "#        => Whitespace),
+            (r#""\x1""#    => Literal(String, "\u{FFFD}")),
+            (r#" "#        => Whitespace),
+            (r#""\x123""#  => Literal(String, "\u{FFFD}")),
+            (r#" "#        => Whitespace),
+            (r#""\u{}""#   => Literal(String, "\u{FFFD}"));
+
+        Severity::Error:
+            (1, 3), (6, 9), (12, 17), (22, 24);
+        }
     }
 
     #[test]
     fn string_incorrect_unicode_braces() {
-        check(&[
-            ScannerTestSlice(r#""\u{123""#,                                 Token::Literal(Lit::String)),
-            ScannerTestSlice(r#" "#,                                        Token::Whitespace),
-            ScannerTestSlice(r#""\u{""#,                                    Token::Literal(Lit::String)),
-            ScannerTestSlice(r#" "#,                                        Token::Whitespace),
-            ScannerTestSlice(r#""\u{uiui}""#,                               Token::Literal(Lit::String)),
-            ScannerTestSlice(r#" "#,                                        Token::Whitespace),
-            ScannerTestSlice(r#""\u{uiui""#,                                Token::Literal(Lit::String)),
-            ScannerTestSlice(r#" "#,                                        Token::Whitespace),
-            ScannerTestSlice(r#""\u{some long string}""#,                   Token::Literal(Lit::String)),
-            ScannerTestSlice(r#" "#,                                        Token::Whitespace),
-            ScannerTestSlice(r#""\u{some long string""#,                    Token::Literal(Lit::String)),
-            ScannerTestSlice(r#" "#,                                        Token::Whitespace),
-            ScannerTestSlice("\"\\u{123, missing\nsome text after that}\"", Token::Literal(Lit::String)),
-            ScannerTestSlice(r#" "#,                                        Token::Whitespace),
-            ScannerTestSlice("\"\\u{456, missing\r\nsome more text\"",      Token::Literal(Lit::String)),
-            ScannerTestSlice(r#" "#,                                        Token::Whitespace),
-            ScannerTestSlice("\"\\u{and bare carriage\rreturn}\"",          Token::Literal(Lit::String)),
-            ScannerTestSlice(r#" "#,                                        Token::Whitespace),
-            ScannerTestSlice("\"\\u{line ends\\\n here}\"",                 Token::Literal(Lit::String)),
-            ScannerTestSlice(r#" "#,                                        Token::Whitespace),
-            ScannerTestSlice("\"\\u{with this\\u{123}\"",                   Token::Literal(Lit::String)),
-            ScannerTestSlice(r#" "#,                                        Token::Whitespace),
-            ScannerTestSlice("\"\\u{or this\\f\"",                          Token::Literal(Lit::String)),
-            ScannerTestSlice(r#" "#,                                        Token::Whitespace),
-            ScannerTestSlice(r#""\u{check missing"#,                        Token::Unrecognized),
-        ], &[
-            Span::new(  7,   7), Span::new( 12,  13), Span::new( 16,  24), Span::new( 34,  34),
-            Span::new( 27,  34), Span::new( 37,  57), Span::new( 79,  79), Span::new( 60,  79),
-            Span::new( 97,  97), Span::new( 82,  97), Span::new(137, 137), Span::new(122, 137),
-            Span::new(156, 184), Span::new(199, 199), Span::new(187, 199), Span::new(222, 222),
-            Span::new(210, 222), Span::new(242, 242), Span::new(232, 242), Span::new(242, 244),
-            Span::new(263, 263), Span::new(247, 263),
-        ], &[
-            Span::new(246, 263),
-        ]);
+        check! {
+            (r#""\u{123""#                                  => Literal(String, "\u{123}")),
+            (r#" "#                                         => Whitespace),
+            (r#""\u{""#                                     => Literal(String, "\u{FFFD}")),
+            (r#" "#                                         => Whitespace),
+            (r#""\u{uiui}""#                                => Literal(String, "\u{FFFD}")),
+            (r#" "#                                         => Whitespace),
+            (r#""\u{uiui""#                                 => Literal(String, "\u{FFFD}")),
+            (r#" "#                                         => Whitespace),
+            (r#""\u{some long string}""#                    => Literal(String, "\u{FFFD}")),
+            (r#" "#                                         => Whitespace),
+            (r#""\u{some long string""#                     => Literal(String, "\u{FFFD}")),
+            (r#" "#                                         => Whitespace),
+            ("\"\\u{123, missing\nsome text after that}\""  => Literal(String, "\u{FFFD}\nsome text after that}")),
+            (r#" "#                                         => Whitespace),
+            ("\"\\u{456, missing\r\nsome more text\""       => Literal(String, "\u{FFFD}\nsome more text")),
+            (r#" "#                                         => Whitespace),
+            ("\"\\u{and bare carriage\rreturn}\""           => Literal(String, "\u{FFFD}")),
+            (r#" "#                                         => Whitespace),
+            ("\"\\u{line ends\\\n here}\""                  => Literal(String, "\u{FFFD}here}")),
+            (r#" "#                                         => Whitespace),
+            ("\"\\u{with this\\u{123}\""                    => Literal(String, "\u{FFFD}\u{123}")),
+            (r#" "#                                         => Whitespace),
+            ("\"\\u{or this\\f\""                           => Literal(String, "\u{FFFD}f")),
+            (r#" "#                                         => Whitespace),
+            (r#""\u{check missing"#                         => Unrecognized);
+
+        Severity::Error:
+            (  7,   7), ( 12,  13), ( 16,  24), ( 34,  34), ( 27,  34), ( 37,  57), ( 79,  79),
+            ( 60,  79), ( 97,  97), ( 82,  97), (137, 137), (122, 137), (156, 184), (199, 199),
+            (187, 199), (222, 222), (210, 222), (242, 242), (232, 242), (242, 244), (263, 263),
+            (247, 263);
+
+        Severity::Fatal:
+            (246, 263);
+        }
     }
 
     #[test]
     fn string_unicode_missing_opening() {
-        check(&[
-            ScannerTestSlice(r#""\u""#,       Token::Literal(Lit::String)),
-            ScannerTestSlice(" ",             Token::Whitespace),
-            ScannerTestSlice(r#""\u}""#,      Token::Literal(Lit::String)),
-            ScannerTestSlice(" ",             Token::Whitespace),
-            ScannerTestSlice(r#""\uguu~""#,   Token::Literal(Lit::String)),
-            ScannerTestSlice(" ",             Token::Whitespace),
-            ScannerTestSlice(r#""\ux\uy""#,   Token::Literal(Lit::String)),
-        ], &[ Span::new(3, 3), Span::new(8, 9), Span::new(14, 14), Span::new(23, 23),
-              Span::new(26, 26) ], &[]);
+        check! {
+            (r#""\u""#      => Literal(String, "\u{FFFD}")),
+            (" "            => Whitespace),
+            (r#""\u}""#     => Literal(String, "\u{FFFD}")),
+            (" "            => Whitespace),
+            (r#""\uguu~""#  => Literal(String, "\u{FFFD}guu~")),
+            (" "            => Whitespace),
+            (r#""\ux\uy""#  => Literal(String, "\u{FFFD}x\u{FFFD}y"));
+
+        Severity::Error:
+            (3, 3), (8, 9), (14, 14), (23, 23), (26, 26);
+        }
     }
 
     #[test]
     fn string_unicode_bare_digits() {
-        check(&[
-            ScannerTestSlice(r#""\u0000\u9\uDEAD\u101111\u99999999999\u1}\u""#, Token::Literal(Lit::String)),
-        ], &[ Span::new( 3,  7), Span::new( 9, 10), Span::new(12, 16), Span::new(10, 16),
-              Span::new(18, 24), Span::new(26, 37), Span::new(24, 37), Span::new(39, 39),
-              Span::new(43, 43),
-        ], &[]);
+        check! {
+            (r#""\u0000\u9\uDEAD\u101111\u99999999999\u1}\u""# => Literal(String, "\u{0}\u{9}\u{FFFD}\u{101111}\u{FFFD}\u{1}\u{FFFD}"));
+
+        Severity::Error:
+            ( 3,  7), ( 9, 10), (12, 16), (10, 16), (18, 24), (26, 37), (24, 37), (39, 39),
+            (43, 43);
+        }
     }
 
     #[test]
     fn string_unknown_escapes() {
-        check(&[
+        check! {
             // Unsupported C escapes
-            ScannerTestSlice("\"\\a\\b\\f\\v\\?\\'\"",    Token::Literal(Lit::String)),
+            ("\"\\a\\b\\f\\v\\?\\'\""   => Literal(String, "abfv?'")),
             // Unsupported hell-knows-whats
-            ScannerTestSlice("\"\\X9\\!\\\u{0742}\\y\"",  Token::Literal(Lit::String)),
-        ], &[ Span::new( 1,  3), Span::new( 3,  5), Span::new( 5,  7), Span::new( 7,  9),
-              Span::new( 9, 11), Span::new(11, 13), Span::new(15, 17), Span::new(18, 20),
-              Span::new(20, 23), Span::new(23, 25), ], &[]);
+            ("\"\\X9\\!\\\u{0742}\\y\"" => Literal(String, "X9!\u{742}y"));
+
+        Severity::Error:
+            ( 1,  3), ( 3,  5), ( 5,  7), ( 7,  9), ( 9, 11), (11, 13), (15, 17), (18, 20),
+            (20, 23), (23, 25);
+        }
     }
 
     // TODO: more tests
 
     #[test]
     fn string_type_suffixes() {
-        check(&[
+        check! {
             // Suffixes are words
-            ScannerTestSlice("\"x\"wide",               Token::Literal(Lit::String)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("\"\t\"ASCII",             Token::Literal(Lit::String)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("\"\\t\"ASCII",            Token::Literal(Lit::String)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("\"\u{3435}\"_",           Token::Literal(Lit::String)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
+            ("\"x\"wide"                    => Literal(String, "x", "wide")),
+            (" "                            => Whitespace),
+            ("\"\t\"ASCII"                  => Literal(String, "\t", "ASCII")),
+            (" "                            => Whitespace),
+            ("\"\\t\"ASCII"                 => Literal(String, "\t", "ASCII")),
+            (" "                            => Whitespace),
+            ("\"\u{3435}\"_"                => Literal(String, "\u{3435}", "_")),
+            (" "                            => Whitespace),
             // And only words, symbols are not suffixes
-            ScannerTestSlice("\"=\"",                   Token::Literal(Lit::String)),
-            ScannerTestSlice("==",                      Token::Identifier),
-            ScannerTestSlice("\"=\"",                   Token::Literal(Lit::String)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
+            ("\"=\""                        => Literal(String, "=")),
+            ("=="                           => Identifier("==")),
+            ("\"=\""                        => Literal(String, "=")),
+            (" "                            => Whitespace),
             // Unicode suffixes
-            ScannerTestSlice("\"\u{1F74}\"\u{1F74}",    Token::Literal(Lit::String)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("\"\\u{1F74}\"\\u{1F74}",  Token::Literal(Lit::String)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-        ], &[], &[]);
+            ("\"\u{1F74}\"\u{1F74}"         => Literal(String, "\u{1F74}", "\u{1F74}")),
+            (" "                            => Whitespace),
+            ("\"\\u{1F74}\"\\u{1F74}"       => Literal(String, "\u{1F74}", "\u{1F74}")),
+            (" "                            => Whitespace);
+        }
     }
 
     #[test]
     fn string_type_suffixes_invalid() {
-        check(&[
+        check! {
             // Inner invalid characters are treated as constituents of suffixes,
             // just as in regular identifiers.
-            ScannerTestSlice("\"fofo\"\\u{47f}\\u{DAAA}",   Token::Literal(Lit::String)),
-            ScannerTestSlice("\"\"b\\u4Fx",                 Token::Literal(Lit::String)),
-            ScannerTestSlice(" ",                           Token::Whitespace),
+            ("\"fofo\"\\u{47f}\\u{DAAA}"    => Literal(String, "fofo", "\u{047F}\u{FFFD}")),
+            ("\"\"b\\u4Fx"                  => Literal(String, "", "b\u{FFFD}x")),
+            (" "                            => Whitespace),
             // However, if a literal is immediately followed by an invalid characters
             // they are not scanned over in anticipation of suffix. They are instantly
             // treated as Token::Unrecognized following the literal
-            ScannerTestSlice("\"\\\"\"",                Token::Literal(Lit::String)),
-            ScannerTestSlice("\\u3F",                   Token::Unrecognized),
-            ScannerTestSlice("\n",                      Token::Whitespace),
-            ScannerTestSlice("\"\\u{F000}\\u{D800}\"",  Token::Literal(Lit::String)),
-            ScannerTestSlice("\\u{F000}",               Token::Unrecognized),
-            ScannerTestSlice("\t",                      Token::Whitespace),
-            ScannerTestSlice("\"foo\"",                 Token::Literal(Lit::String)),
-            ScannerTestSlice("\\",                      Token::Unrecognized),
-            ScannerTestSlice("U900",                    Token::Identifier),
-        ], &[
-            Span::new(13, 21), Span::new(26, 28), Span::new(24, 28), Span::new(36, 38),
-            Span::new(34, 38), Span::new(48, 56), Span::new(57, 65), Span::new(71, 72),
-        ], &[]);
+            ("\"\\\"\""                     => Literal(String, "\"")),
+            ("\\u3F"                        => Unrecognized),
+            ("\n"                           => Whitespace),
+            ("\"\\u{F000}\\u{D800}\""       => Literal(String, "\u{F000}\u{FFFD}")),
+            ("\\u{F000}"                    => Unrecognized),
+            ("\t"                           => Whitespace),
+            ("\"foo\""                      => Literal(String, "foo")),
+            ("\\"                           => Unrecognized),
+            ("U900"                         => Identifier("U900"));
+
+        Severity::Error:
+            (13, 21), (26, 28), (24, 28), (36, 38), (34, 38), (48, 56), (57, 65), (71, 72);
+        }
     }
 
     #[test]
     fn string_type_suffixes_after_invalid() {
-        check(&[
+        check! {
             // Type suffixes are scanned over just fine after invalid strings
-            ScannerTestSlice("\"\\u0\"_\\u0",           Token::Literal(Lit::String)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("\"\\5\"q",                Token::Literal(Lit::String)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("\"\r\"foo",               Token::Literal(Lit::String)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("\"\\x\"zog",              Token::Literal(Lit::String)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("\"\\x4500\"__",           Token::Literal(Lit::String)),
+            ("\"\\u0\"_\\u0"                => Literal(String, "\u{0}", "_\u{FFFD}")),
+            (" "                            => Whitespace),
+            ("\"\\5\"q"                     => Literal(String, "5", "q")),
+            (" "                            => Whitespace),
+            ("\"\r\"foo"                    => Literal(String, "\r", "foo")),
+            (" "                            => Whitespace),
+            ("\"\\x\"zog"                   => Literal(String, "\u{FFFD}", "zog")),
+            (" "                            => Whitespace),
+            ("\"\\x4500\"__"                => Literal(String, "\u{FFFD}", "__"));
             // We aren't able to test missing quotes as they are detected only at EOF
-        ], &[ Span::new( 3,  4), Span::new( 8,  9), Span::new( 6,  9), Span::new(11, 13),
-              Span::new(17, 18), Span::new(24, 26), Span::new(32, 38),
-        ], &[]);
+        Severity::Error:
+            ( 3,  4), ( 8,  9), ( 6,  9), (11, 13), (17, 18), (24, 26), (32, 38);
+        }
     }
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3115,126 +3311,109 @@ mod tests {
 
     #[test]
     fn raw_string_basic() {
-        check(&[
-            ScannerTestSlice("r\"\"",              Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                  Token::Whitespace),
-            ScannerTestSlice("r\"test\"",          Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                  Token::Whitespace),
-            ScannerTestSlice("r\"h\\a\\-\\h\\a\"", Token::Literal(Lit::RawString)),
-        ], &[], &[]);
+        check! {
+            ("r\"\""               => Literal(RawString, "")),
+            (" "                   => Whitespace),
+            ("r\"test\""           => Literal(RawString, "test")),
+            (" "                   => Whitespace),
+            ("r\"h\\a\\-\\h\\a\""  => Literal(RawString, "h\\a\\-\\h\\a"));
+        }
     }
 
     #[test]
     fn raw_string_unicode() {
-        check(&[
-            ScannerTestSlice("r\"\u{0442}\u{044D}\u{0441}\u{0442}\"",
-                                                   Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                  Token::Whitespace),
-            ScannerTestSlice("r\"\u{D1F}\u{D46}\u{D38}\u{D4D}\u{D31}\u{D4D}\u{D31}\u{D4D}\"",
-                                                   Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                  Token::Whitespace),
-            ScannerTestSlice("r\"\u{0074}\u{0068}\u{1EED}\"",
-                                                   Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                  Token::Whitespace),
-            ScannerTestSlice("r\"\u{10E2}\u{10D4}\u{10E1}\u{10E2}\u{10D8}\"",
-                                                   Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                  Token::Whitespace),
-            ScannerTestSlice("r\"\u{100100}\u{100200}\u{103000}\\\u{10FEEE}\u{FEFF}\"",
-                                                   Token::Literal(Lit::RawString)),
-        ], &[], &[]);
+        check! {
+            ("r\"\u{0442}\u{044D}\u{0441}\u{0442}\""                            => Literal(RawString, "\u{0442}\u{044D}\u{0441}\u{0442}")),
+            (" "                                                                => Whitespace),
+            ("r\"\u{D1F}\u{D46}\u{D38}\u{D4D}\u{D31}\u{D4D}\u{D31}\u{D4D}\""    => Literal(RawString, "\u{D1F}\u{D46}\u{D38}\u{D4D}\u{D31}\u{D4D}\u{D31}\u{D4D}")),
+            (" "                                                                => Whitespace),
+            ("r\"\u{0074}\u{0068}\u{1EED}\""                                    => Literal(RawString, "\u{0074}\u{0068}\u{1EED}")),
+            (" "                                                                => Whitespace),
+            ("r\"\u{10E2}\u{10D4}\u{10E1}\u{10E2}\u{10D8}\""                    => Literal(RawString, "\u{10E2}\u{10D4}\u{10E1}\u{10E2}\u{10D8}")),
+            (" "                                                                => Whitespace),
+            ("r\"\u{100100}\u{100200}\u{103000}\\\u{10FEEE}\u{FEFF}\""          => Literal(RawString, "\u{100100}\u{100200}\u{103000}\\\u{10FEEE}\u{FEFF}"));
+        }
     }
 
     #[test]
     fn raw_string_hashed() {
-        check(&[
-            ScannerTestSlice("r\"#\"",             Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                  Token::Whitespace),
-            ScannerTestSlice("r\"##\"",            Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                  Token::Whitespace),
-            ScannerTestSlice("r#\"\"\"\"#",        Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                  Token::Whitespace),
-            ScannerTestSlice("r##\"\"#\"\"##",     Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                  Token::Whitespace),
-            ScannerTestSlice("r###################\"test\"###################", Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                  Token::Whitespace),
-            ScannerTestSlice("r#\"<img src=\"some\test.jpg\"/>\"#", Token::Literal(Lit::RawString)),
-        ], &[], &[]);
+        check! {
+            ("r\"#\""                                           => Literal(RawString, "#")),
+            (" "                                                => Whitespace),
+            ("r\"##\""                                          => Literal(RawString, "##")),
+            (" "                                                => Whitespace),
+            ("r#\"\"\"\"#"                                      => Literal(RawString, "\"\"")),
+            (" "                                                => Whitespace),
+            ("r##\"\"#\"\"##"                                   => Literal(RawString, "\"#\"")),
+            (" "                                                => Whitespace),
+            ("r###################\"test\"###################"  => Literal(RawString, "test")),
+            (" "                                                => Whitespace),
+            ("r#\"<img src=\"some\test.jpg\"/>\"#"              => Literal(RawString, "<img src=\"some\test.jpg\"/>"));
+        }
     }
 
     #[test]
     fn raw_string_multiline() {
-        check(&[
-            ScannerTestSlice("r\"multi\nline\"",        Token::Literal(Lit::RawString)),
-            ScannerTestSlice(",",                       Token::Comma),
-            ScannerTestSlice("r\"windows\r\nline\"",    Token::Literal(Lit::RawString)),
-            ScannerTestSlice(",",                       Token::Comma),
-            ScannerTestSlice("r\"extra\n\n\npadding\"", Token::Literal(Lit::RawString)),
-            ScannerTestSlice(",",                       Token::Comma),
-            ScannerTestSlice("r#\"\"\n\"\n\"#",         Token::Literal(Lit::RawString)),
-            ScannerTestSlice(",",                       Token::Comma),
-            ScannerTestSlice("r##\"\r\n#\r\n\"##",      Token::Literal(Lit::RawString)),
-            ScannerTestSlice(",",                       Token::Comma),
-            ScannerTestSlice("r\"line\\\nbreak\"",      Token::Literal(Lit::RawString)), // These aren't escapes,
-            ScannerTestSlice(",",                       Token::Comma),     // just some slashes
-            ScannerTestSlice("r\"more\\\r\nbreak\"",    Token::Literal(Lit::RawString)), // followed by a newline
-        ], &[], &[]);
+        check! {
+            ("r\"multi\nline\""         => Literal(RawString, "multi\nline")),
+            (","                        => Comma),
+            ("r\"windows\r\nline\""     => Literal(RawString, "windows\nline")),
+            (","                        => Comma),
+            ("r\"extra\n\n\npadding\""  => Literal(RawString, "extra\n\n\npadding")),
+            (","                        => Comma),
+            ("r#\"\"\n\"\n\"#"          => Literal(RawString, "\"\n\"\n")),
+            (","                        => Comma),
+            ("r##\"\r\n#\r\n\"##"       => Literal(RawString, "\n#\n")),
+            (","                        => Comma),
+            // These aren't escapes, just some slashes followed by a newline
+            ("r\"line\\\nbreak\""       => Literal(RawString, "line\\\nbreak")),
+            (","                        => Comma),
+            ("r\"more\\\r\nbreak\""     => Literal(RawString, "more\\\nbreak"));
+        }
     }
 
     #[test]
     fn raw_string_invalid_escape_sequences() {
-        check(&[
-            ScannerTestSlice("r\"\\\"",                 Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("r\"\\\u{1234}\"",         Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("r\"\\u{foo}\\u}{\\ufo\"", Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("r\"\\.\\9\\/\"",          Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("r\"\\xXx\"",              Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("r\"\\r\\#\\m\"",          Token::Literal(Lit::RawString)),
-        ], &[], &[]);
+        check! {
+            ("r\"\\\""                  => Literal(RawString, "\\")),
+            (" "                        => Whitespace),
+            ("r\"\\\u{1234}\""          => Literal(RawString, "\\\u{1234}")),
+            (" "                        => Whitespace),
+            ("r\"\\u{foo}\\u}{\\ufo\""  => Literal(RawString, "\\u{foo}\\u}{\\ufo")),
+            (" "                        => Whitespace),
+            ("r\"\\.\\9\\/\""           => Literal(RawString, "\\.\\9\\/")),
+            (" "                        => Whitespace),
+            ("r\"\\xXx\""               => Literal(RawString, "\\xXx")),
+            (" "                        => Whitespace),
+            ("r\"\\r\\#\\m\""           => Literal(RawString, "\\r\\#\\m"));
+        }
     }
 
     #[test]
     fn raw_string_premature_termination() {
-        check(&[
-            ScannerTestSlice("r\"",               Token::Unrecognized)
-        ], &[], &[ Span::new(0, 2) ]);
-        check(&[
-            ScannerTestSlice("r\"some text",      Token::Unrecognized)
-        ], &[], &[ Span::new(0, 11) ]);
-        check(&[
-            ScannerTestSlice("r\"line\n",         Token::Unrecognized)
-        ], &[], &[ Span::new(0, 7) ]);
-        check(&[
-            ScannerTestSlice("r\"windows\r\n",    Token::Unrecognized)
-        ], &[], &[ Span::new(0, 11) ]);
-        check(&[
-            ScannerTestSlice("r\"bare CR\r",      Token::Unrecognized)
-        ], &[ Span::new(9, 10) ], &[ Span::new(0, 10) ]);
-        check(&[
-            ScannerTestSlice("r#\"text\"",        Token::Unrecognized)
-        ], &[], &[ Span::new(0, 8) ]);
-        check(&[
-            ScannerTestSlice("r###\"te\"#xt\"##", Token::Unrecognized)
-        ], &[], &[ Span::new(0, 14) ]);
-        check(&[
-            ScannerTestSlice("r#\"r\"\"",         Token::Unrecognized)
-        ], &[], &[ Span::new(0, 6) ]);
+        check! { ("r\""               => Unrecognized); Severity::Fatal: (0, 2);  }
+        check! { ("r\"some text"      => Unrecognized); Severity::Fatal: (0, 11); }
+        check! { ("r\"line\n"         => Unrecognized); Severity::Fatal: (0, 7);  }
+        check! { ("r\"windows\r\n"    => Unrecognized); Severity::Fatal: (0, 11); }
+        check! { ("r\"bare CR\r"      => Unrecognized); Severity::Error: (9, 10);
+                                                        Severity::Fatal: (0, 10); }
+        check! { ("r#\"text\""        => Unrecognized); Severity::Fatal: (0, 8);  }
+        check! { ("r###\"te\"#xt\"##" => Unrecognized); Severity::Fatal: (0, 14); }
+        check! { ("r#\"r\"\""         => Unrecognized); Severity::Fatal: (0, 6);  }
     }
 
     #[test]
     fn raw_string_bare_cr() {
-        check(&[
-            ScannerTestSlice("r\"te\rst\"",         Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                   Token::Whitespace),
-            ScannerTestSlice("r\"test\\\r\"",       Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                   Token::Whitespace),
-            ScannerTestSlice("r#\"bare\r\r\rCR\"#", Token::Literal(Lit::RawString)),
-        ], &[ Span::new( 4,  5), Span::new(16, 17), Span::new(26, 27), Span::new(27, 28),
-              Span::new(28, 29) ], &[]);
+        check! {
+            ("r\"te\rst\""                  => Literal(RawString, "te\rst")),
+            (" "                            => Whitespace),
+            ("r\"test\\\r\""                => Literal(RawString, "test\\\r")),
+            (" "                            => Whitespace),
+            ("r#\"bare\r\r\rCR\"#"          => Literal(RawString, "bare\r\r\rCR"));
+
+        Severity::Error:
+            ( 4,  5), (16, 17), (26, 27), (27, 28), (28, 29);
+        }
     }
 
     // TODO: more tests?
@@ -3243,93 +3422,95 @@ mod tests {
 
     #[test]
     fn raw_string_type_suffixes() {
-        check(&[
+        check! {
             // Suffixes are words
-            ScannerTestSlice("r\"x\"wide",              Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("r##\"\t\"##ASCII",        Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("r\"\\t\"ASCII",           Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("r#\"\u{3435}\"#_",        Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
+            ("r\"x\"wide"                   => Literal(RawString, "x", "wide")),
+            (" "                            => Whitespace),
+            ("r##\"\t\"##ASCII"             => Literal(RawString, "\t", "ASCII")),
+            (" "                            => Whitespace),
+            ("r\"\\t\"ASCII"                => Literal(RawString, "\\t", "ASCII")),
+            (" "                            => Whitespace),
+            ("r#\"\u{3435}\"#_"             => Literal(RawString, "\u{3435}", "_")),
+            (" "                            => Whitespace),
             // And only words, symbols are not suffixes
-            ScannerTestSlice("r\"=\"",                  Token::Literal(Lit::RawString)),
-            ScannerTestSlice("==",                      Token::Identifier),
-            ScannerTestSlice("r\"=\"",                  Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
+            ("r\"=\""                       => Literal(RawString, "=")),
+            ("=="                           => Identifier("==")),
+            ("r\"=\""                       => Literal(RawString, "=")),
+            (" "                            => Whitespace),
             // Unicode suffixes
-            ScannerTestSlice("r\"\u{1F74}\"\u{1F74}",   Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("r\"\\u{1F74}\"\\u{1F74}", Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
+            ("r\"\u{1F74}\"\u{1F74}"        => Literal(RawString, "\u{1F74}", "\u{1F74}")),
+            (" "                            => Whitespace),
+            ("r\"\\u{1F74}\"\\u{1F74}"      => Literal(RawString, "\\u{1F74}", "\u{1F74}")),
+            (" "                            => Whitespace),
             // Suffixes (like other tokens) are scanned over geedily, but there
             // is an exception for raw strings. In sequences /r"/ and /r#/, the
             // 'r' character is never considered a type suffix. However, it is
             // true only for the *first* 'r'. Everything else is scanned over
             // greedily as usual.
-            ScannerTestSlice("r\"\"",                   Token::Literal(Lit::RawString)),
-            ScannerTestSlice("r\"\"rr",                 Token::Literal(Lit::RawString)),
-            ScannerTestSlice("\"\"",                    Token::Literal(Lit::String)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("r#\"1\"#",                Token::Literal(Lit::RawString)),
-            ScannerTestSlice("r##\"x\"##",              Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("rawr",                    Token::Identifier),
-            ScannerTestSlice("\"123\"",                 Token::Literal(Lit::String)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("r\"x\"boar",              Token::Literal(Lit::RawString)),
-            ScannerTestSlice("#",                       Token::Hash),
-            ScannerTestSlice("\"x\"",                   Token::Literal(Lit::String)),
-            ScannerTestSlice("#",                       Token::Hash),
-        ], &[], &[]);
+            ("r\"\""                        => Literal(RawString, "")),
+            ("r\"\"rr"                      => Literal(RawString, "", "rr")),
+            ("\"\""                         => Literal(String, "")),
+            (" "                            => Whitespace),
+            ("r#\"1\"#"                     => Literal(RawString, "1")),
+            ("r##\"x\"##"                   => Literal(RawString, "x")),
+            (" "                            => Whitespace),
+            ("rawr"                         => Identifier("rawr")),
+            ("\"123\""                      => Literal(String, "123")),
+            (" "                            => Whitespace),
+            ("r\"x\"boar"                   => Literal(RawString, "x", "boar")),
+            ("#"                            => Hash),
+            ("\"x\""                        => Literal(String, "x")),
+            ("#"                            => Hash);
+        }
     }
 
     #[test]
     fn raw_string_type_suffixes_invalid() {
-        check(&[
+        check! {
             // Inner invalid characters are treated as constituents of suffixes,
             // just as in regular identifiers.
-            ScannerTestSlice("r\"fofo\"\\u{47f}\\u{DAAA}",  Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                           Token::Whitespace),
-            ScannerTestSlice("r#\"\"#b\\u4Fx",              Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                           Token::Whitespace),
+            ("r\"fofo\"\\u{47f}\\u{DAAA}"   => Literal(RawString, "fofo", "\u{047F}\u{FFFD}")),
+            (" "                            => Whitespace),
+            ("r#\"\"#b\\u4Fx"               => Literal(RawString, "", "b\u{FFFD}x")),
+            (" "                            => Whitespace),
             // However, if a literal is immediately followed by an invalid characters
             // they are not scanned over in anticipation of suffix. They are instantly
             // treated as Token::Unrecognized following the literal
-            ScannerTestSlice("r\"\\\"",                     Token::Literal(Lit::RawString)),
-            ScannerTestSlice("\\u3F",                       Token::Unrecognized),
-            ScannerTestSlice("\n",                          Token::Whitespace),
-            ScannerTestSlice("r##\"\\u{F000}\\u{D800}\"##", Token::Literal(Lit::RawString)),
-            ScannerTestSlice("\\u{F000}",                   Token::Unrecognized),
-            ScannerTestSlice("\t",                          Token::Whitespace),
-            ScannerTestSlice("r\"foo\"",                    Token::Literal(Lit::RawString)),
-            ScannerTestSlice("\\",                          Token::Unrecognized),
-            ScannerTestSlice("U900",                        Token::Identifier),
-            ScannerTestSlice("\n",                          Token::Whitespace),
+            ("r\"\\\""                      => Literal(RawString, "\\")),
+            ("\\u3F"                        => Unrecognized),
+            ("\n"                           => Whitespace),
+            ("r##\"\\u{F000}\\u{D800}\"##"  => Literal(RawString, "\\u{F000}\\u{D800}")),
+            ("\\u{F000}"                    => Unrecognized),
+            ("\t"                           => Whitespace),
+            ("r\"foo\""                     => Literal(RawString, "foo")),
+            ("\\"                           => Unrecognized),
+            ("U900"                         => Identifier("U900")),
+            ("\n"                           => Whitespace),
             // Specifically for raw strings: \u{72} is not valid starter for them
-            ScannerTestSlice("r#\"\"#",                     Token::Literal(Lit::RawString)),
-            ScannerTestSlice("\\u{72}",                     Token::Unrecognized),
-            ScannerTestSlice("#",                           Token::Hash),
-            ScannerTestSlice("\"4\"",                       Token::Literal(Lit::String)),
-            ScannerTestSlice("#",                           Token::Hash),
-        ], &[
-            Span::new(14, 22), Span::new(31, 33), Span::new(29, 33), Span::new(41, 43),
-            Span::new(39, 43), Span::new(67, 75), Span::new(82, 83), Span::new(93, 99),
-        ], &[]);
+            ("r#\"\"#"                      => Literal(RawString, "")),
+            ("\\u{72}"                      => Unrecognized),
+            ("#"                            => Hash),
+            ("\"4\""                        => Literal(String, "4")),
+            ("#"                            => Hash);
+
+        Severity::Error:
+            (14, 22), (31, 33), (29, 33), (41, 43), (39, 43), (67, 75), (82, 83), (93, 99);
+        }
     }
 
     #[test]
     fn raw_string_type_suffixes_after_invalid() {
-        check(&[
+        check! {
             // Type suffixes are scanned over just fine after invalid strings
-            ScannerTestSlice("r\"\\u0\"_\\u0",          Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("r##\"\\5\"##q",           Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                       Token::Whitespace),
-            ScannerTestSlice("r\"\r\"foo",              Token::Literal(Lit::RawString)),
+            ("r\"\\u0\"_\\u0"           => Literal(RawString, "\\u0", "_\u{FFFD}")),
+            (" "                        => Whitespace),
+            ("r##\"\\5\"##q"            => Literal(RawString, "\\5", "q")),
+            (" "                        => Whitespace),
+            ("r\"\r\"foo"               => Literal(RawString, "\r", "foo"));
             // We aren't able to test missing quotes as they are detected only at EOF
-        ], &[ Span::new( 9, 10), Span::new( 7, 10), Span::new(24, 25) ], &[]);
+        Severity::Error:
+            ( 9, 10), ( 7, 10), (24, 25);
+        }
     }
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3337,538 +3518,527 @@ mod tests {
 
     #[test]
     fn identifier_ascii_words() {
-        check(&[
-            ScannerTestSlice("word",         Token::Identifier),
-            ScannerTestSlice(" ",            Token::Whitespace),
-            ScannerTestSlice("_underscore_", Token::Identifier),
-            ScannerTestSlice(" ",            Token::Whitespace),
-            ScannerTestSlice("__",           Token::Identifier),
-            ScannerTestSlice(" ",            Token::Whitespace),
-            ScannerTestSlice("x1234567890",  Token::Identifier),
-            ScannerTestSlice(" ",            Token::Whitespace),
-            ScannerTestSlice("_9_",          Token::Identifier),
-            ScannerTestSlice(" ",            Token::Whitespace),
-            ScannerTestSlice("UpperCase",    Token::Identifier),
-            ScannerTestSlice(" ",            Token::Whitespace),
-            ScannerTestSlice("OMG11111",     Token::Identifier),
-        ], &[], &[]);
+        check! {
+            ("word"             => Identifier("word")),
+            (" "                => Whitespace),
+            ("_underscore_"     => Identifier("_underscore_")),
+            (" "                => Whitespace),
+            ("__"               => Identifier("__")),
+            (" "                => Whitespace),
+            ("x1234567890"      => Identifier("x1234567890")),
+            (" "                => Whitespace),
+            ("_9_"              => Identifier("_9_")),
+            (" "                => Whitespace),
+            ("UpperCase"        => Identifier("UpperCase")),
+            (" "                => Whitespace),
+            ("OMG11111"         => Identifier("OMG11111"));
+        }
     }
 
     #[test]
     fn identifier_ascii_marks() {
-        check(&[
-            ScannerTestSlice("+",                Token::Identifier),
-            ScannerTestSlice(" ",                Token::Whitespace),
-            ScannerTestSlice("-",                Token::Identifier),
-            ScannerTestSlice(" ",                Token::Whitespace),
-            ScannerTestSlice("*",                Token::Identifier),
-            ScannerTestSlice(" ",                Token::Whitespace),
-            ScannerTestSlice("/",                Token::Identifier),
-            ScannerTestSlice(" ",                Token::Whitespace),
-            ScannerTestSlice("<=",               Token::Identifier),
-            ScannerTestSlice(" ",                Token::Whitespace),
-            ScannerTestSlice("=",                Token::Identifier),
-            ScannerTestSlice(" ",                Token::Whitespace),
-            ScannerTestSlice("==",               Token::Identifier),
-            ScannerTestSlice(" ",                Token::Whitespace),
-            ScannerTestSlice("..",               Token::Identifier),
-            ScannerTestSlice(" ",                Token::Whitespace),
-            ScannerTestSlice("...",              Token::Identifier),
-            ScannerTestSlice(" ",                Token::Whitespace),
-            ScannerTestSlice("..+..=../..*..",   Token::Identifier),
-            ScannerTestSlice(" ",                Token::Whitespace),
-            ScannerTestSlice("<$>",              Token::Identifier),
-            ScannerTestSlice(" ",                Token::Whitespace),
-            ScannerTestSlice("&&",               Token::Identifier),
-            ScannerTestSlice(" ",                Token::Whitespace),
-            ScannerTestSlice("??",               Token::Identifier),
-            ScannerTestSlice(" ",                Token::Whitespace),
-            ScannerTestSlice("+++",              Token::Identifier),
-            ScannerTestSlice(" ",                Token::Whitespace),
-            ScannerTestSlice("%/%",              Token::Identifier),
-            ScannerTestSlice(" ",                Token::Whitespace),
-            ScannerTestSlice("<$%&*+|-~/=@^>!?", Token::Identifier),
-        ], &[], &[]);
+        check! {
+            ("+"                => Identifier("+")),
+            (" "                => Whitespace),
+            ("-"                => Identifier("-")),
+            (" "                => Whitespace),
+            ("*"                => Identifier("*")),
+            (" "                => Whitespace),
+            ("/"                => Identifier("/")),
+            (" "                => Whitespace),
+            ("<="               => Identifier("<=")),
+            (" "                => Whitespace),
+            ("="                => Identifier("=")),
+            (" "                => Whitespace),
+            ("=="               => Identifier("==")),
+            (" "                => Whitespace),
+            (".."               => Identifier("..")),
+            (" "                => Whitespace),
+            ("..."              => Identifier("...")),
+            (" "                => Whitespace),
+            ("..+..=../..*.."   => Identifier("..+..=../..*..")),
+            (" "                => Whitespace),
+            ("<$>"              => Identifier("<$>")),
+            (" "                => Whitespace),
+            ("&&"               => Identifier("&&")),
+            (" "                => Whitespace),
+            ("??"               => Identifier("??")),
+            (" "                => Whitespace),
+            ("+++"              => Identifier("+++")),
+            (" "                => Whitespace),
+            ("%/%"              => Identifier("%/%")),
+            (" "                => Whitespace),
+            ("<$%&*+|-~/=@^>!?" => Identifier("<$%&*+|-~/=@^>!?"));
+        }
     }
 
     #[test]
     fn identifier_unicode_words() {
-        check(&[
+        check! {
     // Lu, Ll, Lo
-            ScannerTestSlice("\u{0054}\u{0068}\u{1EED}\u{005F}\u{006E}\u{0067}\u{0068}\u{0069}\
-                              \u{1EC7}\u{006D}",                            Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{0583}\u{0578}\u{0580}\u{0571}\u{0561}\u{0580}\u{056F}\u{0578}\
-                              \u{0582}\u{0574}",                            Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{0422}\u{0435}\u{0441}\u{0442}\u{0423}\u{0432}\u{0430}\u{043D}\
-                              \u{043D}\u{042F}",                            Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{09AA}\u{09B0}\u{09C0}\u{0995}\u{09CD}\u{09B7}\u{09BE}\u{09AE}\
-                              \u{09C2}\u{09B2}\u{0995}",                    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{691C}\u{67FB}",                            Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{062A}\u{062C}\u{0631}\u{064A}\u{0628}",    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{1780}\u{17B6}\u{179A}\u{1792}\u{17D2}\u{179C}\u{17BE}\u{178F}\
-                              \u{17C1}\u{179F}\u{17D2}\u{178F}",            Token::Identifier),
-
-            ScannerTestSlice(" ",                                           Token::Whitespace),
+            ("\u{0054}\u{0068}\u{1EED}\u{005F}\u{006E}\u{0067}\u{0068}\u{0069}\u{1EC7}\u{006D}"                 => Identifier("\u{0054}\u{0068}\u{1EED}\u{005F}\u{006E}\u{0067}\u{0068}\u{0069}\u{1EC7}\u{006D}")),
+            (" "                                                                                                => Whitespace),
+            ("\u{0583}\u{0578}\u{0580}\u{0571}\u{0561}\u{0580}\u{056F}\u{0578}\u{0582}\u{0574}"                 => Identifier("\u{0583}\u{0578}\u{0580}\u{0571}\u{0561}\u{0580}\u{056F}\u{0578}\u{0582}\u{0574}")),
+            (" "                                                                                                => Whitespace),
+            ("\u{0422}\u{0435}\u{0441}\u{0442}\u{0423}\u{0432}\u{0430}\u{043D}\u{043D}\u{042F}"                 => Identifier("\u{0422}\u{0435}\u{0441}\u{0442}\u{0423}\u{0432}\u{0430}\u{043D}\u{043D}\u{042F}")),
+            (" "                                                                                                => Whitespace),
+            ("\u{09AA}\u{09B0}\u{09C0}\u{0995}\u{09CD}\u{09B7}\u{09BE}\u{09AE}\u{09C2}\u{09B2}\u{0995}"         => Identifier("\u{09AA}\u{09B0}\u{09C0}\u{0995}\u{09CD}\u{09B7}\u{09BE}\u{09AE}\u{09C2}\u{09B2}\u{0995}")),
+            (" "                                                                                                => Whitespace),
+            ("\u{691C}\u{67FB}"                                                                                 => Identifier("\u{691C}\u{67FB}")),
+            (" "                                                                                                => Whitespace),
+            ("\u{062A}\u{062C}\u{0631}\u{064A}\u{0628}"                                                         => Identifier("\u{062A}\u{062C}\u{0631}\u{064A}\u{0628}")),
+            (" "                                                                                                => Whitespace),
+            ("\u{1780}\u{17B6}\u{179A}\u{1792}\u{17D2}\u{179C}\u{17BE}\u{178F}\u{17C1}\u{179F}\u{17D2}\u{178F}" => Identifier("\u{1780}\u{17B6}\u{179A}\u{1792}\u{17D2}\u{179C}\u{17BE}\u{178F}\u{17C1}\u{179F}\u{17D2}\u{178F}")),
+            (" "                                                                                                => Whitespace),
     // Lt
-            ScannerTestSlice("\u{01F2}\u{0061}\u{0031}",                    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{1FAA}",                                    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
+            ("\u{01F2}\u{0061}\u{0031}"                                                                         => Identifier("\u{01F2}\u{0061}\u{0031}")),
+            (" "                                                                                                => Whitespace),
+            ("\u{1FAA}"                                                                                         => Identifier("\u{1FAA}")),
+            (" "                                                                                                => Whitespace),
     // Lm
-            ScannerTestSlice("\u{1D2E}\u{1D43}\u{1D48}",                    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{02C7}\u{02E4}\u{06E6}",                    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
+            ("\u{1D2E}\u{1D43}\u{1D48}"                                                                         => Identifier("\u{1D2E}\u{1D43}\u{1D48}")),
+            (" "                                                                                                => Whitespace),
+            ("\u{02C7}\u{02E4}\u{06E6}"                                                                         => Identifier("\u{02C7}\u{02E4}\u{06E6}")),
+            (" "                                                                                                => Whitespace),
     // Nl
-            ScannerTestSlice("\u{2169}\u{216C}\u{2164}",                    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{3007}\u{3007}\u{3007}",                    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{12461}\u{12468}",                          Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
+            ("\u{2169}\u{216C}\u{2164}"                                                                         => Identifier("\u{2169}\u{216C}\u{2164}")),
+            (" "                                                                                                => Whitespace),
+            ("\u{3007}\u{3007}\u{3007}"                                                                         => Identifier("\u{3007}\u{3007}\u{3007}")),
+            (" "                                                                                                => Whitespace),
+            ("\u{12461}\u{12468}"                                                                               => Identifier("\u{12461}\u{12468}")),
+            (" "                                                                                                => Whitespace),
     // Other_ID_Start
-            ScannerTestSlice("\u{2118}\u{212E}",                            Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{212E}\u{2118}",                            Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
+            ("\u{2118}\u{212E}"                                                                                 => Identifier("\u{2118}\u{212E}")),
+            (" "                                                                                                => Whitespace),
+            ("\u{212E}\u{2118}"                                                                                 => Identifier("\u{212E}\u{2118}")),
+            (" "                                                                                                => Whitespace),
     // Mn (continue)
-            ScannerTestSlice("\u{0043}\u{0364}\u{0348}\u{0359}\u{0345}\u{032E}\u{0323}\u{035A}\
-              \u{0074}\u{0342}\u{0351}\u{0351}\u{0309}\u{0363}\u{0301}\u{035E}\u{0331}\u{0325}\
-              \u{032A}\u{034E}\u{0329}\u{031E}\u{0068}\u{035F}\u{0075}\u{0368}\u{0365}\u{0359}\
-              \u{006C}\u{036E}\u{0307}\u{0358}\u{031E}\u{0356}\u{0329}\u{0330}\u{0326}\u{0068}\
-              \u{0351}\u{030C}\u{0312}\u{0367}\u{033C}\u{035A}\u{0075}\u{0350}\u{034A}\u{036E}\
-              \u{0336}\u{0329}\u{0320}\u{031E}",                            Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
+            ("\u{0043}\u{0364}\u{0348}\u{0359}\u{0345}\u{032E}\u{0323}\u{035A}\u{0074}\u{0342}\u{0351}\u{0351}\u{0309}\
+              \u{0363}\u{0301}\u{035E}\u{0331}\u{0325}\u{032A}\u{034E}\u{0329}\u{031E}\u{0068}\u{035F}\u{0075}\u{0368}\
+              \u{0365}\u{0359}\u{006C}\u{036E}\u{0307}\u{0358}\u{031E}\u{0356}\u{0329}\u{0330}\u{0326}\u{0068}\u{0351}\
+              \u{030C}\u{0312}\u{0367}\u{033C}\u{035A}\u{0075}\u{0350}\u{034A}\u{036E}\u{0336}\u{0329}\u{0320}\u{031E}"
+            => Identifier(
+             "\u{0043}\u{0364}\u{0348}\u{0359}\u{0345}\u{032E}\u{0323}\u{035A}\u{0074}\u{0342}\u{0351}\u{0351}\u{0309}\
+              \u{0363}\u{0301}\u{035E}\u{0331}\u{0325}\u{032A}\u{034E}\u{0329}\u{031E}\u{0068}\u{035F}\u{0075}\u{0368}\
+              \u{0365}\u{0359}\u{006C}\u{036E}\u{0307}\u{0358}\u{031E}\u{0356}\u{0329}\u{0330}\u{0326}\u{0068}\u{0351}\
+              \u{030C}\u{0312}\u{0367}\u{033C}\u{035A}\u{0075}\u{0350}\u{034A}\u{036E}\u{0336}\u{0329}\u{0320}\u{031E}")),
+            (" " => Whitespace),
     // Mc (continue)
-            ScannerTestSlice("\u{09A6}\u{09C0}\u{09B0}\u{09CD}\u{0998}",    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{0932}\u{0902}\u{092C}\u{0947}\u{005F}\u{0938}\u{092E}\u{092F}\
-                              \u{005F}\u{0924}\u{0915}",                    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
+            ("\u{09A6}\u{09C0}\u{09B0}\u{09CD}\u{0998}"                                                         => Identifier("\u{09A6}\u{09C0}\u{09B0}\u{09CD}\u{0998}")),
+            (" "                                                                                                => Whitespace),
+            ("\u{0932}\u{0902}\u{092C}\u{0947}\u{005F}\u{0938}\u{092E}\u{092F}\u{005F}\u{0924}\u{0915}"         => Identifier("\u{0932}\u{0902}\u{092C}\u{0947}\u{005F}\u{0938}\u{092E}\u{092F}\u{005F}\u{0924}\u{0915}")),
+            (" "                                                                                                => Whitespace),
     // Nd (continue)
-            ScannerTestSlice("\u{005F}\u{0661}\u{0665}",                    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{0996}\u{09BE}\u{09A6}\u{09CD}\u{09AF}\u{09E7}\u{0AE7}\u{0DE9}\
-                              \u{1040}\u{A8D6}",                            Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
+            ("\u{005F}\u{0661}\u{0665}"                                                                         => Identifier("\u{005F}\u{0661}\u{0665}")),
+            (" "                                                                                                => Whitespace),
+            ("\u{0996}\u{09BE}\u{09A6}\u{09CD}\u{09AF}\u{09E7}\u{0AE7}\u{0DE9}\u{1040}\u{A8D6}"                 => Identifier("\u{0996}\u{09BE}\u{09A6}\u{09CD}\u{09AF}\u{09E7}\u{0AE7}\u{0DE9}\u{1040}\u{A8D6}")),
+            (" "                                                                                                => Whitespace),
     // Pc (continue)
-            ScannerTestSlice("\u{0061}\u{203F}\u{0062}",                    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{0078}\u{FE4D}\u{0079}",                    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{005F}\u{FE4F}\u{005F}",                    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
+            ("\u{0061}\u{203F}\u{0062}"                                                                         => Identifier("\u{0061}\u{203F}\u{0062}")),
+            (" "                                                                                                => Whitespace),
+            ("\u{0078}\u{FE4D}\u{0079}"                                                                         => Identifier("\u{0078}\u{FE4D}\u{0079}")),
+            (" "                                                                                                => Whitespace),
+            ("\u{005F}\u{FE4F}\u{005F}"                                                                         => Identifier("\u{005F}\u{FE4F}\u{005F}")),
+            (" "                                                                                                => Whitespace),
     // Other_ID_Continue
-            ScannerTestSlice("\u{0057}\u{00B7}\u{006F}\u{00B7}\u{0057}",    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{1213}\u{121F}\u{1226}\u{1369}\u{136A}\u{136B}\u{136C}\u{136D}\
-                              \u{136E}\u{136F}\u{1370}\u{1371}",            Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{03A4}\u{0387}\u{03C1}\u{0387}\u{03BF}\u{0387}\u{03C6}\u{0387}\
-                              \u{03AE}\u{0387}",                            Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{0078}\u{19DA}",                            Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
+            ("\u{0057}\u{00B7}\u{006F}\u{00B7}\u{0057}"                                                         => Identifier("\u{0057}\u{00B7}\u{006F}\u{00B7}\u{0057}")),
+            (" "                                                                                                => Whitespace),
+            ("\u{1213}\u{121F}\u{1226}\u{1369}\u{136A}\u{136B}\u{136C}\u{136D}\u{136E}\u{136F}\u{1370}\u{1371}" => Identifier("\u{1213}\u{121F}\u{1226}\u{1369}\u{136A}\u{136B}\u{136C}\u{136D}\u{136E}\u{136F}\u{1370}\u{1371}")),
+            (" "                                                                                                => Whitespace),
+            ("\u{03A4}\u{0387}\u{03C1}\u{0387}\u{03BF}\u{0387}\u{03C6}\u{0387}\u{03AE}\u{0387}"                 => Identifier("\u{03A4}\u{0387}\u{03C1}\u{0387}\u{03BF}\u{0387}\u{03C6}\u{0387}\u{03AE}\u{0387}")),
+            (" "                                                                                                => Whitespace),
+            ("\u{0078}\u{19DA}"                                                                                 => Identifier("\u{0078}\u{19DA}")),
+            (" "                                                                                                => Whitespace),
     // ZWJ, ZWNJ
-            ScannerTestSlice("\u{0CA8}\u{0CCD}\u{0CA8}",                    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{0CA8}\u{0CCD}\u{200C}\u{0CA8}",            Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{0915}\u{094D}\u{0937}",                    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{0915}\u{094D}\u{200D}\u{0937}",            Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{0645}\u{06CC}\u{200C}\u{062E}\u{0648}\u{0627}\u{0647}\u{0645}",
-                                                                            Token::Identifier),
-        ], &[], &[]);
+            ("\u{0CA8}\u{0CCD}\u{0CA8}"                                                                         => Identifier("\u{0CA8}\u{0CCD}\u{0CA8}")),
+            (" "                                                                                                => Whitespace),
+            ("\u{0CA8}\u{0CCD}\u{200C}\u{0CA8}"                                                                 => Identifier("\u{0CA8}\u{0CCD}\u{200C}\u{0CA8}")),
+            (" "                                                                                                => Whitespace),
+            ("\u{0915}\u{094D}\u{0937}"                                                                         => Identifier("\u{0915}\u{094D}\u{0937}")),
+            (" "                                                                                                => Whitespace),
+            ("\u{0915}\u{094D}\u{200D}\u{0937}"                                                                 => Identifier("\u{0915}\u{094D}\u{200D}\u{0937}")),
+            (" "                                                                                                => Whitespace),
+            ("\u{0645}\u{06CC}\u{200C}\u{062E}\u{0648}\u{0627}\u{0647}\u{0645}"                                 => Identifier("\u{0645}\u{06CC}\u{200C}\u{062E}\u{0648}\u{0627}\u{0647}\u{0645}"));
+        }
     }
 
     #[test]
     fn identifier_unicode_marks() {
-        check(&[
+        check! {
     // Pd
-            ScannerTestSlice("\u{2015}\u{301C}\u{FE31}\u{2010}\u{30A0}",Token::Identifier),
-            ScannerTestSlice(" ",                                       Token::Whitespace),
+            ("\u{2015}\u{301C}\u{FE31}\u{2010}\u{30A0}"                 => Identifier("\u{2015}\u{301C}\u{FE31}\u{2010}\u{30A0}")),
+            (" "                                                        => Whitespace),
     // Po
-            ScannerTestSlice("\u{00B6}\u{066A}\u{1364}",                Token::Identifier),
-            ScannerTestSlice(" ",                                       Token::Whitespace),
-            ScannerTestSlice("\u{2042}\u{2037}\u{203B}",                Token::Identifier),
-            ScannerTestSlice(" ",                                       Token::Whitespace),
-            ScannerTestSlice("\u{203C}\u{A8CE}\u{FE60}\u{FF0A}",        Token::Identifier),
-            ScannerTestSlice(" ",                                       Token::Whitespace),
-            ScannerTestSlice("\u{110BB}\u{111DD}\u{115C9}",             Token::Identifier),
-            ScannerTestSlice(" ",                                       Token::Whitespace),
-            ScannerTestSlice("\u{2025}",                                Token::Identifier),
-            ScannerTestSlice(" ",                                       Token::Whitespace),
-            ScannerTestSlice("\u{2026}",                                Token::Identifier),
-            ScannerTestSlice(" ",                                       Token::Whitespace),
+            ("\u{00B6}\u{066A}\u{1364}"                                 => Identifier("\u{00B6}\u{066A}\u{1364}")),
+            (" "                                                        => Whitespace),
+            ("\u{2042}\u{2037}\u{203B}"                                 => Identifier("\u{2042}\u{2037}\u{203B}")),
+            (" "                                                        => Whitespace),
+            ("\u{203C}\u{A8CE}\u{FE60}\u{FF0A}"                         => Identifier("\u{203C}\u{A8CE}\u{FE60}\u{FF0A}")),
+            (" "                                                        => Whitespace),
+            ("\u{110BB}\u{111DD}\u{115C9}"                              => Identifier("\u{110BB}\u{111DD}\u{115C9}")),
+            (" "                                                        => Whitespace),
+            ("\u{2025}"                                                 => Identifier("\u{2025}")),
+            (" "                                                        => Whitespace),
+            ("\u{2026}"                                                 => Identifier("\u{2026}")),
+            (" "                                                        => Whitespace),
     // Sc
-            ScannerTestSlice("\u{00A2}\u{00A5}\u{20A1}\u{0BF9}\u{20B8}\u{FE69}\u{FF04}",
-                                                                        Token::Identifier),
-            ScannerTestSlice(" ",                                       Token::Whitespace),
+            ("\u{00A2}\u{00A5}\u{20A1}\u{0BF9}\u{20B8}\u{FE69}\u{FF04}" => Identifier("\u{00A2}\u{00A5}\u{20A1}\u{0BF9}\u{20B8}\u{FE69}\u{FF04}")),
+            (" "                                                        => Whitespace),
     // Sm
-            ScannerTestSlice("\u{00D7}\u{207C}",                        Token::Identifier),
-            ScannerTestSlice(" ",                                       Token::Whitespace),
-            ScannerTestSlice("\u{2192}\u{2192}\u{2194}",                Token::Identifier),
-            ScannerTestSlice(" ",                                       Token::Whitespace),
-            ScannerTestSlice("\u{220F}\u{2230}",                        Token::Identifier),
-            ScannerTestSlice(" ",                                       Token::Whitespace),
-            ScannerTestSlice("\u{2257}",                                Token::Identifier),
-            ScannerTestSlice(" ",                                       Token::Whitespace),
-            ScannerTestSlice("\u{229D}\u{2AF7}\u{2AF5}",                Token::Identifier),
-            ScannerTestSlice(" ",                                       Token::Whitespace),
+            ("\u{00D7}\u{207C}"                                         => Identifier("\u{00D7}\u{207C}")),
+            (" "                                                        => Whitespace),
+            ("\u{2192}\u{2192}\u{2194}"                                 => Identifier("\u{2192}\u{2192}\u{2194}")),
+            (" "                                                        => Whitespace),
+            ("\u{220F}\u{2230}"                                         => Identifier("\u{220F}\u{2230}")),
+            (" "                                                        => Whitespace),
+            ("\u{2257}"                                                 => Identifier("\u{2257}")),
+            (" "                                                        => Whitespace),
+            ("\u{229D}\u{2AF7}\u{2AF5}"                                 => Identifier("\u{229D}\u{2AF7}\u{2AF5}")),
+            (" "                                                        => Whitespace),
     // So
-            ScannerTestSlice("\u{00A9}\u{06DE}\u{0BF5}",                Token::Identifier),
-            ScannerTestSlice(" ",                                       Token::Whitespace),
-            ScannerTestSlice("\u{19FB}\u{19FF}",                        Token::Identifier),
-            ScannerTestSlice(" ",                                       Token::Whitespace),
-            ScannerTestSlice("\u{2127}\u{21B5}\u{21BA}",                Token::Identifier),
-            ScannerTestSlice(" ",                                       Token::Whitespace),
-            ScannerTestSlice("\u{2375}\u{236A}\u{2361}\u{2360}",        Token::Identifier),
-            ScannerTestSlice(" ",                                       Token::Whitespace),
-            ScannerTestSlice("\u{2569}\u{2566}\u{2573}\u{2588}",        Token::Identifier),
-            ScannerTestSlice(" ",                                       Token::Whitespace),
-            ScannerTestSlice("\u{25E9}\u{2625}\u{2639}\u{265B}\u{2690}",Token::Identifier),
-            ScannerTestSlice(" ",                                       Token::Whitespace),
-            ScannerTestSlice("\u{26B5}\u{1D1E7}",                       Token::Identifier),
-            ScannerTestSlice(" ",                                       Token::Whitespace),
-            ScannerTestSlice("\u{1D332}\u{1D354}\u{1D940}",             Token::Identifier),
-            ScannerTestSlice(" ",                                       Token::Whitespace),
-            ScannerTestSlice("\u{1F300}\u{1F401}\u{1F423}\u{1F4B3}\u{1F980}",
-                                                                        Token::Identifier),
-            ScannerTestSlice(" ",                                       Token::Whitespace),
+            ("\u{00A9}\u{06DE}\u{0BF5}"                                 => Identifier("\u{00A9}\u{06DE}\u{0BF5}")),
+            (" "                                                        => Whitespace),
+            ("\u{19FB}\u{19FF}"                                         => Identifier("\u{19FB}\u{19FF}")),
+            (" "                                                        => Whitespace),
+            ("\u{2127}\u{21B5}\u{21BA}"                                 => Identifier("\u{2127}\u{21B5}\u{21BA}")),
+            (" "                                                        => Whitespace),
+            ("\u{2375}\u{236A}\u{2361}\u{2360}"                         => Identifier("\u{2375}\u{236A}\u{2361}\u{2360}")),
+            (" "                                                        => Whitespace),
+            ("\u{2569}\u{2566}\u{2573}\u{2588}"                         => Identifier("\u{2569}\u{2566}\u{2573}\u{2588}")),
+            (" "                                                        => Whitespace),
+            ("\u{25E9}\u{2625}\u{2639}\u{265B}\u{2690}"                 => Identifier("\u{25E9}\u{2625}\u{2639}\u{265B}\u{2690}")),
+            (" "                                                        => Whitespace),
+            ("\u{26B5}\u{1D1E7}"                                        => Identifier("\u{26B5}\u{1D1E7}")),
+            (" "                                                        => Whitespace),
+            ("\u{1D332}\u{1D354}\u{1D940}"                              => Identifier("\u{1D332}\u{1D354}\u{1D940}")),
+            (" "                                                        => Whitespace),
+            ("\u{1F300}\u{1F401}\u{1F423}\u{1F4B3}\u{1F980}"            => Identifier("\u{1F300}\u{1F401}\u{1F423}\u{1F4B3}\u{1F980}")),
+            (" "                                                        => Whitespace),
     // Mc (continue)
-            ScannerTestSlice("\u{0021}\u{17BF}\u{0026}\u{0DDB}\u{002A}\u{0CCB}",
-                                                                        Token::Identifier),
-            ScannerTestSlice(" ",                                       Token::Whitespace),
+            ("\u{0021}\u{17BF}\u{0026}\u{0DDB}\u{002A}\u{0CCB}"         => Identifier("\u{0021}\u{17BF}\u{0026}\u{0DDB}\u{002A}\u{0CCB}")),
+            (" "                                                        => Whitespace),
     // Me (continue)
-            ScannerTestSlice("\u{0024}\u{0488}",                        Token::Identifier),
-            ScannerTestSlice(" ",                                       Token::Whitespace),
-            ScannerTestSlice("\u{003C}\u{20DD}\u{003E}\u{20DE}",        Token::Identifier),
-            ScannerTestSlice(" ",                                       Token::Whitespace),
-            ScannerTestSlice("\u{0021}\u{20DF}",                        Token::Identifier),
-            ScannerTestSlice(" ",                                       Token::Whitespace),
+            ("\u{0024}\u{0488}"                                         => Identifier("\u{0024}\u{0488}")),
+            (" "                                                        => Whitespace),
+            ("\u{003C}\u{20DD}\u{003E}\u{20DE}"                         => Identifier("\u{003C}\u{20DD}\u{003E}\u{20DE}")),
+            (" "                                                        => Whitespace),
+            ("\u{0021}\u{20DF}"                                         => Identifier("\u{0021}\u{20DF}")),
+            (" "                                                        => Whitespace),
     // Mn (continue)
-            ScannerTestSlice("\u{227A}\u{0307}\u{0301}\u{0301}\u{030D}\u{030C}\u{0311}\u{033C}\
-              \u{0353}\u{0359}\u{2203}\u{034F}\u{0317}\u{2202}\u{0363}\u{036B}\u{0342}\u{0342}\
-              \u{035B}\u{031A}\u{0317}\u{033C}\u{0356}\u{031C}\u{0323}\u{2200}\u{033B}\u{033C}\
-              \u{222D}\u{030E}\u{030F}\u{032D}\u{033A}",                Token::Identifier),
-        ], &[], &[]);
+            ("\u{227A}\u{0307}\u{0301}\u{0301}\u{030D}\u{030C}\u{0311}\u{033C}\u{0353}\u{0359}\
+              \u{2203}\u{034F}\u{0317}\u{2202}\u{0363}\u{036B}\u{0342}\u{0342}\u{035B}\u{031A}\
+              \u{0317}\u{033C}\u{0356}\u{031C}\u{0323}\u{2200}\u{033B}\u{033C}\u{222D}\u{030E}\
+              \u{030F}\u{032D}\u{033A}"
+            => Identifier(
+             "\u{227A}\u{0307}\u{0301}\u{0301}\u{030D}\u{030C}\u{0311}\u{033C}\u{0353}\u{0359}\
+              \u{2203}\u{034F}\u{0317}\u{2202}\u{0363}\u{036B}\u{0342}\u{0342}\u{035B}\u{031A}\
+              \u{0317}\u{033C}\u{0356}\u{031C}\u{0323}\u{2200}\u{033B}\u{033C}\u{222D}\u{030E}\
+              \u{030F}\u{032D}\u{033A}"));
+        }
     }
 
     #[test]
     fn identifier_unicode_delimiters() {
-        check(&[
+        check! {
     // Ps
-            ScannerTestSlice("\u{2045}",    Token::Identifier),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice("\u{2768}",    Token::Identifier),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice("\u{2774}",    Token::Identifier),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice("\u{300E}",    Token::Identifier),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice("\u{FE3D}",    Token::Identifier),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice("\u{FE5D}",    Token::Identifier),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice("\u{2987}",    Token::Identifier),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice("\u{3008}",    Token::Identifier),
-            ScannerTestSlice(" ",           Token::Whitespace),
+            ("\u{2045}"     => Identifier("\u{2045}")),
+            (" "            => Whitespace),
+            ("\u{2768}"     => Identifier("\u{2768}")),
+            (" "            => Whitespace),
+            ("\u{2774}"     => Identifier("\u{2774}")),
+            (" "            => Whitespace),
+            ("\u{300E}"     => Identifier("\u{300E}")),
+            (" "            => Whitespace),
+            ("\u{FE3D}"     => Identifier("\u{FE3D}")),
+            (" "            => Whitespace),
+            ("\u{FE5D}"     => Identifier("\u{FE5D}")),
+            (" "            => Whitespace),
+            ("\u{2987}"     => Identifier("\u{2987}")),
+            (" "            => Whitespace),
+            ("\u{3008}"     => Identifier("\u{3008}")),
+            (" "            => Whitespace),
     // Pe
-            ScannerTestSlice("\u{0F3B}",    Token::Identifier),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice("\u{0F3D}",    Token::Identifier),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice("\u{276B}",    Token::Identifier),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice("\u{300B}",    Token::Identifier),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice("\u{FE18}",    Token::Identifier),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice("\u{FF63}",    Token::Identifier),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice("\u{2992}",    Token::Identifier),
-            ScannerTestSlice(" ",           Token::Whitespace),
+            ("\u{0F3B}"     => Identifier("\u{0F3B}")),
+            (" "            => Whitespace),
+            ("\u{0F3D}"     => Identifier("\u{0F3D}")),
+            (" "            => Whitespace),
+            ("\u{276B}"     => Identifier("\u{276B}")),
+            (" "            => Whitespace),
+            ("\u{300B}"     => Identifier("\u{300B}")),
+            (" "            => Whitespace),
+            ("\u{FE18}"     => Identifier("\u{FE18}")),
+            (" "            => Whitespace),
+            ("\u{FF63}"     => Identifier("\u{FF63}")),
+            (" "            => Whitespace),
+            ("\u{2992}"     => Identifier("\u{2992}")),
+            (" "            => Whitespace),
     // Pi
-            ScannerTestSlice("\u{00AB}",    Token::Identifier),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice("\u{201B}",    Token::Identifier),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice("\u{2E02}",    Token::Identifier),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice("\u{2E09}",    Token::Identifier),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice("\u{2E1C}",    Token::Identifier),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice("\u{2E20}",    Token::Identifier),
-            ScannerTestSlice(" ",           Token::Whitespace),
+            ("\u{00AB}"     => Identifier("\u{00AB}")),
+            (" "            => Whitespace),
+            ("\u{201B}"     => Identifier("\u{201B}")),
+            (" "            => Whitespace),
+            ("\u{2E02}"     => Identifier("\u{2E02}")),
+            (" "            => Whitespace),
+            ("\u{2E09}"     => Identifier("\u{2E09}")),
+            (" "            => Whitespace),
+            ("\u{2E1C}"     => Identifier("\u{2E1C}")),
+            (" "            => Whitespace),
+            ("\u{2E20}"     => Identifier("\u{2E20}")),
+            (" "            => Whitespace),
     // Pf
-            ScannerTestSlice("\u{00BB}",    Token::Identifier),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice("\u{2E03}",    Token::Identifier),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice("\u{203A}",    Token::Identifier),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice("\u{2E21}",    Token::Identifier),
-            ScannerTestSlice(" ",           Token::Whitespace),
-            ScannerTestSlice("\u{2019}",    Token::Identifier),
-        ], &[], &[]);
+            ("\u{00BB}"     => Identifier("\u{00BB}")),
+            (" "            => Whitespace),
+            ("\u{2E03}"     => Identifier("\u{2E03}")),
+            (" "            => Whitespace),
+            ("\u{203A}"     => Identifier("\u{203A}")),
+            (" "            => Whitespace),
+            ("\u{2E21}"     => Identifier("\u{2E21}")),
+            (" "            => Whitespace),
+            ("\u{2019}"     => Identifier("\u{2019}"));
+        }
     }
 
     #[test]
     fn identifier_escape_basic() {
-        check(&[
-            ScannerTestSlice(r"\u{0442}\u{0435}\u{0441}\u{0442}",           Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice(r"\u{01CB}\u{114D1}\u{114D2}\u{114D3}",        Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice(r"\u{062A}\u{062C}\u{0631}\u{064A}\u{0628}",   Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice(r"\u{2026}\u{2026}\u{2026}",                   Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice(r"\u{00A9}\u{06DE}\u{0BF5}",                   Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice(r"demo\u{Ff11}\u{ff12}\u{fF13}",               Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{041F}\u{0440}\\u{043E}\u{0432}\u{0435}\\u{0440}\u{043A}\\u{0430}",
-                                                                            Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("!\\u{20DF}",                                  Token::Identifier),
-        ], &[], &[]);
+        check! {
+            (r"\u{0442}\u{0435}\u{0441}\u{0442}"            => Identifier("\u{0442}\u{0435}\u{0441}\u{0442}")),
+            (" "                                            => Whitespace),
+            (r"\u{01CB}\u{114D1}\u{114D2}\u{114D3}"         => Identifier("\u{01CB}\u{114D1}\u{114D2}\u{114D3}")),
+            (" "                                            => Whitespace),
+            (r"\u{062A}\u{062C}\u{0631}\u{064A}\u{0628}"    => Identifier("\u{062A}\u{062C}\u{0631}\u{064A}\u{0628}")),
+            (" "                                            => Whitespace),
+            (r"\u{2026}\u{2026}\u{2026}"                    => Identifier("\u{2026}\u{2026}\u{2026}")),
+            (" "                                            => Whitespace),
+            (r"\u{00A9}\u{06DE}\u{0BF5}"                    => Identifier("\u{00A9}\u{06DE}\u{0BF5}")),
+            (" "                                            => Whitespace),
+            (r"demo\u{Ff11}\u{ff12}\u{fF13}"                => Identifier("demo\u{Ff11}\u{ff12}\u{fF13}")),
+            (" "                                            => Whitespace),
+            ("\u{041F}\u{0440}\\u{043E}\u{0432}\u{0435}\\u{0440}\u{043A}\\u{0430}" => Identifier("\u{041F}\u{0440}\u{043E}\u{0432}\u{0435}\u{0440}\u{043A}\u{0430}")),
+            (" "                                            => Whitespace),
+            ("!\\u{20DF}"                                   => Identifier("!\u{20DF}"));
+        }
     }
 
     #[test]
     fn identifier_boundary_rules() {
-        check(&[
+        check! {
     // Word | Mark
-            ScannerTestSlice("a",                                           Token::Identifier),
-            ScannerTestSlice("/",                                           Token::Identifier),
-            ScannerTestSlice("b",                                           Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("x9",                                          Token::Identifier),
-            ScannerTestSlice("..",                                          Token::Identifier),
-            ScannerTestSlice("y",                                           Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("*",                                           Token::Identifier),
-            ScannerTestSlice("_",                                           Token::Identifier),
-            ScannerTestSlice("*",                                           Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{03BD}\u{03B5}\u{03C1}\u{03CC}",            Token::Identifier),
-            ScannerTestSlice("\u{002B}",                                    Token::Identifier),
-            ScannerTestSlice("\u{03C6}\u{03C9}\u{03C4}\u{03B9}\u{03AC}",    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{221A}",                                    Token::Identifier),
-            ScannerTestSlice("\u{0078}",                                    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{222D}",                                    Token::Identifier),
-            ScannerTestSlice("\u{092E}\u{094C}\u{091C}\u{093C}\u{093E}",    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{29BF}",                                    Token::Identifier),
-            ScannerTestSlice("\u{006F}",                                    Token::Identifier),
-            ScannerTestSlice("\u{29BF}",                                    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("<",                                           Token::Identifier),
-            ScannerTestSlice("pre\u{0301}sident",                           Token::Identifier),
-            ScannerTestSlice(">",                                           Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{003D}\u{033F}",                            Token::Identifier),
-            ScannerTestSlice("\u{0078}\u{033F}",                            Token::Identifier),
-            ScannerTestSlice("\u{003D}\u{033F}",                            Token::Identifier),
-            ScannerTestSlice("\n",                                          Token::Whitespace),
+            ("a"                                            => Identifier("a")),
+            ("/"                                            => Identifier("/")),
+            ("b"                                            => Identifier("b")),
+            (" "                                            => Whitespace),
+            ("x9"                                           => Identifier("x9")),
+            (".."                                           => Identifier("..")),
+            ("y"                                            => Identifier("y")),
+            (" "                                            => Whitespace),
+            ("*"                                            => Identifier("*")),
+            ("_"                                            => Identifier("_")),
+            ("*"                                            => Identifier("*")),
+            (" "                                            => Whitespace),
+            ("\u{03BD}\u{03B5}\u{03C1}\u{03CC}"             => Identifier("\u{03BD}\u{03B5}\u{03C1}\u{03CC}")),
+            ("\u{002B}"                                     => Identifier("\u{002B}")),
+            ("\u{03C6}\u{03C9}\u{03C4}\u{03B9}\u{03AC}"     => Identifier("\u{03C6}\u{03C9}\u{03C4}\u{03B9}\u{03AC}")),
+            (" "                                            => Whitespace),
+            ("\u{221A}"                                     => Identifier("\u{221A}")),
+            ("\u{0078}"                                     => Identifier("\u{0078}")),
+            (" "                                            => Whitespace),
+            ("\u{222D}"                                     => Identifier("\u{222D}")),
+            ("\u{092E}\u{094C}\u{091C}\u{093C}\u{093E}"     => Identifier("\u{092E}\u{094C}\u{091C}\u{093C}\u{093E}")),
+            (" "                                            => Whitespace),
+            ("\u{29BF}"                                     => Identifier("\u{29BF}")),
+            ("\u{006F}"                                     => Identifier("\u{006F}")),
+            ("\u{29BF}"                                     => Identifier("\u{29BF}")),
+            (" "                                            => Whitespace),
+            ("<"                                            => Identifier("<")),
+            ("pre\u{0301}sident"                            => Identifier("pre\u{0301}sident")),
+            (">"                                            => Identifier(">")),
+            (" "                                            => Whitespace),
+            ("\u{003D}\u{033F}"                             => Identifier("\u{003D}\u{033F}")),
+            ("\u{0078}\u{033F}"                             => Identifier("\u{0078}\u{033F}")),
+            ("\u{003D}\u{033F}"                             => Identifier("\u{003D}\u{033F}")),
+            ("\n"                                           => Whitespace),
     // Word | Quote
-            ScannerTestSlice("\u{00AB}",                                    Token::Identifier),
-            ScannerTestSlice("word",                                        Token::Identifier),
-            ScannerTestSlice("\u{00BB}",                                    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{3008}",                                    Token::Identifier),
-            ScannerTestSlice("x",                                           Token::Identifier),
-            ScannerTestSlice("|",                                           Token::Identifier),
-            ScannerTestSlice("y",                                           Token::Identifier),
-            ScannerTestSlice("\u{3009}",                                    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{FE43}",                                    Token::Identifier),
-            ScannerTestSlice("\u{3060}\u{307E}\u{3057}\u{307E}\u{3059}",    Token::Identifier),
-            ScannerTestSlice("\u{FE44}",                                    Token::Identifier),
-            ScannerTestSlice("\n",                                          Token::Whitespace),
+            ("\u{00AB}"                                     => Identifier("\u{00AB}")),
+            ("word"                                         => Identifier("word")),
+            ("\u{00BB}"                                     => Identifier("\u{00BB}")),
+            (" "                                            => Whitespace),
+            ("\u{3008}"                                     => Identifier("\u{3008}")),
+            ("x"                                            => Identifier("x")),
+            ("|"                                            => Identifier("|")),
+            ("y"                                            => Identifier("y")),
+            ("\u{3009}"                                     => Identifier("\u{3009}")),
+            (" "                                            => Whitespace),
+            ("\u{FE43}"                                     => Identifier("\u{FE43}")),
+            ("\u{3060}\u{307E}\u{3057}\u{307E}\u{3059}"     => Identifier("\u{3060}\u{307E}\u{3057}\u{307E}\u{3059}")),
+            ("\u{FE44}"                                     => Identifier("\u{FE44}")),
+            ("\n"                                           => Whitespace),
     // Mark | Quote
-            ScannerTestSlice("\u{0F3A}",                                    Token::Identifier),
-            ScannerTestSlice("\u{2015}",                                    Token::Identifier),
-            ScannerTestSlice("\u{0F3B}",                                    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{00A5}",                                    Token::Identifier),
-            ScannerTestSlice("\u{301D}",                                    Token::Identifier),
-            ScannerTestSlice("\u{00A5}",                                    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{228F}\u{0BC6}",                            Token::Identifier),
-            ScannerTestSlice("\u{FE5D}",                                    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{FE3E}",                                    Token::Identifier),
-            ScannerTestSlice("\u{27A4}",                                    Token::Identifier),
-            ScannerTestSlice("\u{FE3E}",                                    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{1F39B}\u{20E3}",                           Token::Identifier),
-            ScannerTestSlice("\u{2E21}",                                    Token::Identifier),
-            ScannerTestSlice("\u{1F39B}\u{20E3}",                           Token::Identifier),
-            ScannerTestSlice("\n",                                          Token::Whitespace),
+            ("\u{0F3A}"                                     => Identifier("\u{0F3A}")),
+            ("\u{2015}"                                     => Identifier("\u{2015}")),
+            ("\u{0F3B}"                                     => Identifier("\u{0F3B}")),
+            (" "                                            => Whitespace),
+            ("\u{00A5}"                                     => Identifier("\u{00A5}")),
+            ("\u{301D}"                                     => Identifier("\u{301D}")),
+            ("\u{00A5}"                                     => Identifier("\u{00A5}")),
+            (" "                                            => Whitespace),
+            ("\u{228F}\u{0BC6}"                             => Identifier("\u{228F}\u{0BC6}")),
+            ("\u{FE5D}"                                     => Identifier("\u{FE5D}")),
+            (" "                                            => Whitespace),
+            ("\u{FE3E}"                                     => Identifier("\u{FE3E}")),
+            ("\u{27A4}"                                     => Identifier("\u{27A4}")),
+            ("\u{FE3E}"                                     => Identifier("\u{FE3E}")),
+            (" "                                            => Whitespace),
+            ("\u{1F39B}\u{20E3}"                            => Identifier("\u{1F39B}\u{20E3}")),
+            ("\u{2E21}"                                     => Identifier("\u{2E21}")),
+            ("\u{1F39B}\u{20E3}"                            => Identifier("\u{1F39B}\u{20E3}")),
+            ("\n"                                           => Whitespace),
     // Quote | Quote
-            ScannerTestSlice("\u{201D}",                                    Token::Identifier),
-            ScannerTestSlice("\u{201D}",                                    Token::Identifier),
-            ScannerTestSlice("\u{00AB}",                                    Token::Identifier),
-            ScannerTestSlice("\u{00AB}",                                    Token::Identifier),
-            ScannerTestSlice("\u{2039}",                                    Token::Identifier),
-            ScannerTestSlice("\u{203A}",                                    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{2E21}",                                    Token::Identifier),
-            ScannerTestSlice("\u{2045}",                                    Token::Identifier),
-            ScannerTestSlice("\u{2770}",                                    Token::Identifier),
-            ScannerTestSlice("\u{2770}",                                    Token::Identifier),
-            ScannerTestSlice("\u{0F3D}",                                    Token::Identifier),
-            ScannerTestSlice("\u{276F}",                                    Token::Identifier),
-            ScannerTestSlice("\u{300F}",                                    Token::Identifier),
-        ], &[], &[]);
+            ("\u{201D}"                                     => Identifier("\u{201D}")),
+            ("\u{201D}"                                     => Identifier("\u{201D}")),
+            ("\u{00AB}"                                     => Identifier("\u{00AB}")),
+            ("\u{00AB}"                                     => Identifier("\u{00AB}")),
+            ("\u{2039}"                                     => Identifier("\u{2039}")),
+            ("\u{203A}"                                     => Identifier("\u{203A}")),
+            (" "                                            => Whitespace),
+            ("\u{2E21}"                                     => Identifier("\u{2E21}")),
+            ("\u{2045}"                                     => Identifier("\u{2045}")),
+            ("\u{2770}"                                     => Identifier("\u{2770}")),
+            ("\u{2770}"                                     => Identifier("\u{2770}")),
+            ("\u{0F3D}"                                     => Identifier("\u{0F3D}")),
+            ("\u{276F}"                                     => Identifier("\u{276F}")),
+            ("\u{300F}"                                     => Identifier("\u{300F}"));
+        }
     }
 
     #[test]
     fn identifier_boundary_rules_escapes() {
-        check(&[
+        check! {
     // Word | Mark
-            ScannerTestSlice(r"a",                                          Token::Identifier),
-            ScannerTestSlice(r"\u{2215}",                                   Token::Identifier),
-            ScannerTestSlice(r"b",                                          Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\\u{29BF}",                                   Token::Identifier),
-            ScannerTestSlice("\u{03BF}",                                    Token::Identifier),
-            ScannerTestSlice("\\u{29BF}",                                   Token::Identifier),
-            ScannerTestSlice("\n",                                          Token::Whitespace),
+            (r"a"                                           => Identifier("a")),
+            (r"\u{2215}"                                    => Identifier("\u{2215}")),
+            (r"b"                                           => Identifier("b")),
+            (" "                                            => Whitespace),
+            ("\\u{29BF}"                                    => Identifier("\u{29BF}")),
+            ("\u{03BF}"                                     => Identifier("\u{03BF}")),
+            ("\\u{29BF}"                                    => Identifier("\u{29BF}")),
+            ("\n"                                           => Whitespace),
     // Word | Quote
-            ScannerTestSlice(r"\u{00AB}",                                   Token::Identifier),
-            ScannerTestSlice(r"w\u{2113}\u{1d466}d",                        Token::Identifier),
-            ScannerTestSlice("\u{00BB}",                                    Token::Identifier),
-            ScannerTestSlice("\n",                                          Token::Whitespace),
+            (r"\u{00AB}"                                    => Identifier("\u{00AB}")),
+            (r"w\u{2113}\u{1d466}d"                         => Identifier("w\u{2113}\u{1D466}d")),
+            ("\u{00BB}"                                     => Identifier("\u{00BB}")),
+            ("\n"                                           => Whitespace),
     // Mark | Quote
-            ScannerTestSlice("\\u{1F39B}\u{20E3}",                          Token::Identifier),
-            ScannerTestSlice("\u{2E21}",                                    Token::Identifier),
-            ScannerTestSlice("\u{1F39B}\\u{20E3}",                          Token::Identifier),
-            ScannerTestSlice("\n",                                          Token::Whitespace),
+            ("\\u{1F39B}\u{20E3}"                           => Identifier("\u{1F39B}\u{20E3}")),
+            ("\u{2E21}"                                     => Identifier("\u{2E21}")),
+            ("\u{1F39B}\\u{20E3}"                           => Identifier("\u{1F39B}\u{20E3}")),
+            ("\n"                                           => Whitespace),
     // Quote | Quote
-            ScannerTestSlice("\u{2E21}",                                    Token::Identifier),
-            ScannerTestSlice("\\u{2045}",                                   Token::Identifier),
-            ScannerTestSlice("\u{2770}",                                    Token::Identifier),
-        ], &[], &[]);
+            ("\u{2E21}"                                     => Identifier("\u{2E21}")),
+            ("\\u{2045}"                                    => Identifier("\u{2045}")),
+            ("\u{2770}"                                     => Identifier("\u{2770}"));
+        }
     }
 
     #[test]
     fn identifier_escape_missing_braces() {
-        check(&[
+        check! {
             // One can get away with just error messages when there are no braces
             // around otherwise correct scalar values
-            ScannerTestSlice(r"\u0442\u0435\u0441\u0442",                   Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\\u1794\u{17C3}\\u178F\\u{1784}",             Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
+            (r"\u0442\u0435\u0441\u0442"                => Identifier("\u{0442}\u{0435}\u{0441}\u{0442}")),
+            (" "                                        => Whitespace),
+            ("\\u1794\u{17C3}\\u178F\\u{1784}"          => Identifier("\u{1794}\u{17C3}\u{178F}\u{1784}")),
+            (" "                                        => Whitespace),
             // Even boundary detection rules work in this case
-            ScannerTestSlice(r"\u212f}",                                    Token::Identifier),
-            ScannerTestSlice(r"\u2212}",                                    Token::Identifier),
-            ScannerTestSlice(r"\u2134}",                                    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice(r"\u276E",                                     Token::Identifier),
-            ScannerTestSlice(r"\u{72D7}",                                   Token::Identifier),
-            ScannerTestSlice(r"\u300B",                                     Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
+            (r"\u212f}"                                 => Identifier("\u{212F}")),
+            (r"\u2212}"                                 => Identifier("\u{2212}")),
+            (r"\u2134}"                                 => Identifier("\u{2134}")),
+            (" "                                        => Whitespace),
+            (r"\u276E"                                  => Identifier("\u{276E}")),
+            (r"\u{72D7}"                                => Identifier("\u{72D7}")),
+            (r"\u300B"                                  => Identifier("\u{300B}")),
+            (" "                                        => Whitespace),
             // Given correct scalar values, we can also cope with missing starting/closing brace
-            ScannerTestSlice(r"\u{221B\u2192}\u2192\u{2192\u2192",          Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
+            (r"\u{221B\u2192}\u2192\u{2192\u2192"       => Identifier("\u{221B}\u{2192}\u{2192}\u{2192}\u{2192}")),
+            (" "                                        => Whitespace),
             // However, if the starting Unicode escape is invalid, it is simply skipped over
-            ScannerTestSlice(r"\u",                                         Token::Unrecognized),
-            ScannerTestSlice(r"!",                                          Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice(r"\u",                                         Token::Unrecognized),
-            ScannerTestSlice(r"g",                                          Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice(r"\u{}",                                       Token::Unrecognized),
-            ScannerTestSlice(r"==",                                         Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice(r"\u",                                         Token::Unrecognized),
-            ScannerTestSlice("::",                                          Token::Dualcolon),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice(r"\u",                                         Token::Unrecognized),
-            ScannerTestSlice("]",                                           Token::CloseDelim(Delimiter::Bracket)),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\\u",                                         Token::Unrecognized),
-            ScannerTestSlice("\u{301b}",                                    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice(r"\u",                                         Token::Unrecognized),
-            ScannerTestSlice(r"\u{301b}",                                   Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
+            (r"\u"                                      => Unrecognized),
+            (r"!"                                       => Identifier("!")),
+            (" "                                        => Whitespace),
+            (r"\u"                                      => Unrecognized),
+            (r"g"                                       => Identifier("g")),
+            (" "                                        => Whitespace),
+            (r"\u{}"                                    => Unrecognized),
+            (r"=="                                      => Identifier("==")),
+            (" "                                        => Whitespace),
+            (r"\u"                                      => Unrecognized),
+            ("::"                                       => Dualcolon),
+            (" "                                        => Whitespace),
+            (r"\u"                                      => Unrecognized),
+            ("]"                                        => CloseDelim(Bracket)),
+            (" "                                        => Whitespace),
+            ("\\u"                                      => Unrecognized),
+            ("\u{301b}"                                 => Identifier("\u{301B}")),
+            (" "                                        => Whitespace),
+            (r"\u"                                      => Unrecognized),
+            (r"\u{301b}"                                => Identifier("\u{301B}")),
+            (" "                                        => Whitespace),
             // As in characters, line endings are used to detect missing closing braces
-            ScannerTestSlice(r"\u{30C7}\u{30E2}\u{308",                     Token::Identifier),
-            ScannerTestSlice("\n",                                          Token::Whitespace),
+            (r"\u{30C7}\u{30E2}\u{308"                  => Identifier("\u{30C7}\u{30E2}\u{0308}")),
+            ("\n"                                       => Whitespace),
             // And unexpected EOFs can happen with identifiers too, thought they are not fatal
-            ScannerTestSlice(r"\u{914",                                     Token::Identifier),
-        ], &[
-            Span::new(  2,   6), Span::new(  8,  12), Span::new( 14,  18), Span::new( 20,  24),
-            Span::new( 27,  31), Span::new( 36,  40), Span::new( 51,  51), Span::new( 58,  58),
-            Span::new( 65,  65), Span::new( 73,  77), Span::new( 87,  91), Span::new( 99,  99),
-            Span::new(101, 101), Span::new(108, 112), Span::new(119, 119), Span::new(121, 125),
-            Span::new(128, 128), Span::new(126, 128), Span::new(132, 132), Span::new(130, 132),
-            Span::new(136, 138), Span::new(134, 138), Span::new(143, 143), Span::new(141, 143),
-            Span::new(148, 148), Span::new(146, 148), Span::new(152, 152), Span::new(150, 152),
-            Span::new(158, 158), Span::new(156, 158), Span::new(189, 189), Span::new(196, 196),
-        ], &[]);
+            (r"\u{914"                                  => Identifier("\u{0914}"));
+
+        Severity::Error:
+            (  2,   6), (  8,  12), ( 14,  18), ( 20,  24), ( 27,  31), ( 36,  40), ( 51,  51),
+            ( 58,  58), ( 65,  65), ( 73,  77), ( 87,  91), ( 99,  99), (101, 101), (108, 112),
+            (119, 119), (121, 125), (128, 128), (126, 128), (132, 132), (130, 132), (136, 138),
+            (134, 138), (143, 143), (141, 143), (148, 148), (146, 148), (152, 152), (150, 152),
+            (158, 158), (156, 158), (189, 189), (196, 196);
+        }
     }
 
     #[test]
     fn identifier_escape_invalid_values() {
-        check(&[
+        check! {
             // As in characters or strings, missing values, surrogate code points, out-or-range
             // values, and non-scalar values are not okay
-            ScannerTestSlice("fo\\u{}o",                                    Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("bar\\u{D900}",                                Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("b\\u{9999999999}az",                          Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("D\\u{COMBINING ACUTE ACCENT}mo",              Token::Identifier),
-            ScannerTestSlice("\n",                                          Token::Whitespace),
+            ("fo\\u{}o"                                     => Identifier("fo\u{FFFD}o")),
+            (" "                                            => Whitespace),
+            ("bar\\u{D900}"                                 => Identifier("bar\u{FFFD}")),
+            (" "                                            => Whitespace),
+            ("b\\u{9999999999}az"                           => Identifier("b\u{FFFD}az")),
+            (" "                                            => Whitespace),
+            ("D\\u{COMBINING ACUTE ACCENT}mo"               => Identifier("D\u{FFFD}mo")),
+            ("\n"                                           => Whitespace),
             // For boundary detection these are treated as valid values in whatever context we are
-            ScannerTestSlice(r"\u{D800}\u{DDDD}",                           Token::Unrecognized),
-            ScannerTestSlice(r"_1\u{DFFF}",                                 Token::Identifier),
-            ScannerTestSlice(r"+\u{DEAD}\u{D912}",                          Token::Identifier),
-            ScannerTestSlice(r"\u{2985}",                                   Token::Identifier),
-            ScannerTestSlice(r" ",                                          Token::Whitespace),
-            ScannerTestSlice(r"\u{9999999999999}",                          Token::Unrecognized),
-            ScannerTestSlice(r"==\u{Fo fo fo!}\u{a7}",                      Token::Identifier),
-            ScannerTestSlice("\n",                                          Token::Whitespace),
+            (r"\u{D800}\u{DDDD}"                            => Unrecognized),
+            (r"_1\u{DFFF}"                                  => Identifier("_1\u{FFFD}")),
+            (r"+\u{DEAD}\u{D912}"                           => Identifier("+\u{FFFD}\u{FFFD}")),
+            (r"\u{2985}"                                    => Identifier("\u{2985}")),
+            (r" "                                           => Whitespace),
+            (r"\u{9999999999999}"                           => Unrecognized),
+            (r"==\u{Fo fo fo!}\u{a7}"                       => Identifier("==\u{FFFD}\u{00A7}")),
+            ("\n"                                           => Whitespace),
             // But invalid values are not start codes. For example, an entirely invalid sequence
             // will not count as an identifier. The digits that immediately follow it are a part
             // of a number, they do not count as XID_Continue which magically converts the whole
             // thing into a word identifier. The scanner never backtracks.
-            ScannerTestSlice(r"\u{Some}\u{Invalid}\u{Stuff}",               Token::Unrecognized),
-            ScannerTestSlice(r"123",                                        Token::Literal(Lit::Integer)),
-            ScannerTestSlice(r" ",                                          Token::Whitespace),
-            ScannerTestSlice(r"\u{Some}\u{Invalid}\u{Stuff}",               Token::Unrecognized),
-            ScannerTestSlice(r"_123",                                       Token::Identifier),
-        ], &[
-            Span::new(  4,   6), Span::new( 11,  19), Span::new( 21,  35), Span::new( 39,  65),
-            Span::new( 68,  76), Span::new( 76,  84), Span::new( 68,  84), Span::new( 86,  94),
-            Span::new( 95, 103), Span::new(103, 111), Span::new(120, 137), Span::new(120, 137),
-            Span::new(139, 152), Span::new(159, 167), Span::new(167, 178), Span::new(178, 187),
-            Span::new(159, 187), Span::new(191, 199), Span::new(199, 210), Span::new(210, 219),
-            Span::new(191, 219),
-         ], &[]);
+            (r"\u{Some}\u{Invalid}\u{Stuff}"                => Unrecognized),
+            (r"123"                                         => Literal(Integer, "123")),
+            (r" "                                           => Whitespace),
+            (r"\u{Some}\u{Invalid}\u{Stuff}"                => Unrecognized),
+            (r"_123"                                        => Identifier("_123"));
+
+        Severity::Error:
+            (  4,   6), ( 11,  19), ( 21,  35), ( 39,  65), ( 68,  76), ( 76,  84), ( 68,  84),
+            ( 86,  94), ( 95, 103), (103, 111), (120, 137), (120, 137), (139, 152), (159, 167),
+            (167, 178), (178, 187), (159, 187), (191, 199), (199, 210), (210, 219), (191, 219);
+        }
     }
 
     #[test]
     fn identifier_invalid_characters_plain() {
-        check(&[
+        check! {
             // Arbitrary Unicode character sequences are considered invalid. Peculiar cases
             // in ASCII include control codes (other than whitespace), and  backslashes (\)
             // which are not immediately followed by 'u'. Non-ASCII cases include usage of
@@ -3876,152 +4046,150 @@ mod tests {
             // No, Sk, or C), or usage of bare identifier continuation characters (without
             // a starter character preceding them). The whole hunk of such invalid characters
             // is reported as Unrecognized.
-            ScannerTestSlice("\u{00}\u{03}\u{04}\u{05}\u{06}\u{07}\u{08}",  Token::Unrecognized),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{12}\u{1A}\u{1B}\u{1C}",                    Token::Unrecognized),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{1D}\u{1E}\u{1F}\u{7F}\u{80}\u{81}",        Token::Unrecognized),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{82}\u{83}\u{84}",                          Token::Unrecognized),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{e123}\u{F700}\u{FF000}\u{100000}",         Token::Unrecognized),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{200B}\u{180E}\u{2062}\u{E0001}\u{E007F}",  Token::Unrecognized),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\\",                                          Token::Unrecognized),
-            ScannerTestSlice("x12",                                         Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\\\\",                                        Token::Unrecognized),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("test\\",                                      Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{0307}\u{09E3}\\\u{1DA61}\u{200D}",         Token::Unrecognized),
-            ScannerTestSlice("1",                                           Token::Literal(Lit::Integer)),
-            ScannerTestSlice("\u{200C}\u{7F}\u{200D}",                      Token::Unrecognized),
-            ScannerTestSlice("x\u{200D}y",                                  Token::Identifier),
-            ScannerTestSlice("\n",                                          Token::Whitespace),
+            ("\u{00}\u{03}\u{04}\u{05}\u{06}\u{07}\u{08}"   => Unrecognized),
+            (" "                                            => Whitespace),
+            ("\u{12}\u{1A}\u{1B}\u{1C}"                     => Unrecognized),
+            (" "                                            => Whitespace),
+            ("\u{1D}\u{1E}\u{1F}\u{7F}\u{80}\u{81}"         => Unrecognized),
+            (" "                                            => Whitespace),
+            ("\u{82}\u{83}\u{84}"                           => Unrecognized),
+            (" "                                            => Whitespace),
+            ("\u{e123}\u{F700}\u{FF000}\u{100000}"          => Unrecognized),
+            (" "                                            => Whitespace),
+            ("\u{200B}\u{180E}\u{2062}\u{E0001}\u{E007F}"   => Unrecognized),
+            (" "                                            => Whitespace),
+            ("\\"                                           => Unrecognized),
+            ("x12"                                          => Identifier("x12")),
+            (" "                                            => Whitespace),
+            ("\\\\"                                         => Unrecognized),
+            (" "                                            => Whitespace),
+            ("test\\"                                       => Identifier("test\\")),
+            (" "                                            => Whitespace),
+            ("\u{0307}\u{09E3}\\\u{1DA61}\u{200D}"          => Unrecognized),
+            ("1"                                            => Literal(Integer, "1")),
+            ("\u{200C}\u{7F}\u{200D}"                       => Unrecognized),
+            ("x\u{200D}y"                                   => Identifier("x\u{200D}y")),
+            ("\n"                                           => Whitespace),
             // However! The scanner tolerates invalid Unicode characters in the middle of
             // identifiers. They are still reported, but the scanning goes on afterwards
             // as if they were valid, including their usage for boundary detection.
-            ScannerTestSlice("f\u{0}o",                                     Token::Identifier),
-            ScannerTestSlice("+\u{E666}",                                   Token::Identifier),
-            ScannerTestSlice("_\u{10}some\u{11}_\\invalid\\123",            Token::Identifier),
-            ScannerTestSlice("==\u{02DC}==",                                Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("a\u{0488}b",                                  Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("C\u{20DD}_\u{20E3}",                          Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("+\u{200D}+=\u{200D}",                         Token::Identifier),
-        ], &[
-            Span::new(  0,   7), Span::new(  8,  12), Span::new( 13,  21), Span::new( 22,  28),
-            Span::new( 29,  43), Span::new( 44,  61), Span::new( 62,  63), Span::new( 67,  69),
-            Span::new( 74,  75), Span::new( 76,  89), Span::new( 90,  97), Span::new(104, 105),
-            Span::new(107, 110), Span::new(111, 112), Span::new(116, 117), Span::new(118, 119),
-            Span::new(126, 127), Span::new(132, 134), Span::new(138, 140), Span::new(143, 146),
-            Span::new(147, 150), Span::new(152, 155), Span::new(157, 160),
-        ], &[]);
+            ("f\u{0}o"                                      => Identifier("f\u{0}o")),
+            ("+\u{E666}"                                    => Identifier("+\u{E666}")),
+            ("_\u{10}some\u{11}_\\invalid\\123"             => Identifier("_\u{10}some\u{11}_\\invalid\\123")),
+            ("==\u{02DC}=="                                 => Identifier("==\u{02DC}==")),
+            (" "                                            => Whitespace),
+            ("a\u{0488}b"                                   => Identifier("a\u{0488}b")),
+            (" "                                            => Whitespace),
+            ("C\u{20DD}_\u{20E3}"                           => Identifier("C\u{20DD}_\u{20E3}")),
+            (" "                                            => Whitespace),
+            ("+\u{200D}+=\u{200D}"                          => Identifier("+\u{200D}+=\u{200D}"));
+
+        Severity::Error:
+            (  0,   7), (  8,  12), ( 13,  21), ( 22,  28), ( 29,  43), ( 44,  61), ( 62,  63),
+            ( 67,  69), ( 74,  75), ( 76,  89), ( 90,  97), (104, 105), (107, 110), (111, 112),
+            (116, 117), (118, 119), (126, 127), (132, 134), (138, 140), (143, 146), (147, 150),
+            (152, 155), (157, 160);
+        }
     }
 
     #[test]
     fn identifier_invalid_characters_escaped() {
-        check(&[
+        check! {
             // The scanner also tolerates (i.e., is able to recover from) invalid escaped Unicode
             // characters in the middle of identifiers. This also includes surrogates (which can't
             // be embedded into Rust strings as is), and other invalid escapes.
-            ScannerTestSlice(r"f\u{2000}o",                                 Token::Identifier),
-            ScannerTestSlice(r"+\u{E666}",                                  Token::Identifier),
-            ScannerTestSlice(r"_\u{60}some\u{7F}_\invalid\123",             Token::Identifier),
-            ScannerTestSlice(r"==\u{02DC}==",                               Token::Identifier),
-            ScannerTestSlice(r" ",                                          Token::Whitespace),
-            ScannerTestSlice(r"a\u{0488}b",                                 Token::Identifier),
-            ScannerTestSlice(r" ",                                          Token::Whitespace),
-            ScannerTestSlice(r"C\u{20DD}_\u{20E3}",                         Token::Identifier),
-            ScannerTestSlice(r" ",                                          Token::Whitespace),
-            ScannerTestSlice(r"+\u{200D}+=\u{200D}",                        Token::Identifier),
-            ScannerTestSlice(r" ",                                          Token::Whitespace),
-            ScannerTestSlice(r"f\u{}o",                                     Token::Identifier),
-            ScannerTestSlice(r" ",                                          Token::Whitespace),
-            ScannerTestSlice(r"f\u{REPLACEMENT CHARACTER}o",                Token::Identifier),
-            ScannerTestSlice(r"+\uD900\uDDDD",                              Token::Identifier),
-            ScannerTestSlice(r"_\u{9999999999999999}_",                     Token::Identifier),
-        ], &[ Span::new(  1,   9), Span::new( 11,  19), Span::new( 20,  26), Span::new( 30,  36),
-              Span::new( 37,  38), Span::new( 45,  46), Span::new( 51,  59), Span::new( 63,  71),
-              Span::new( 74,  82), Span::new( 83,  91), Span::new( 93, 101), Span::new(103, 111),
-              Span::new(115, 117), Span::new(120, 145), Span::new(149, 153), Span::new(147, 153),
-              Span::new(155, 159), Span::new(153, 159), Span::new(160, 180),
-        ], &[]);
+            (r"f\u{2000}o"                                  => Identifier("f\u{2000}o")),
+            (r"+\u{E666}"                                   => Identifier("+\u{E666}")),
+            (r"_\u{60}some\u{7F}_\invalid\123"              => Identifier("_\u{FFFD}some\u{FFFD}_\\invalid\\123")),
+            (r"==\u{02DC}=="                                => Identifier("==\u{02DC}==")),
+            (r" "                                           => Whitespace),
+            (r"a\u{0488}b"                                  => Identifier("a\u{0488}b")),
+            (r" "                                           => Whitespace),
+            (r"C\u{20DD}_\u{20E3}"                          => Identifier("C\u{20DD}_\u{20E3}")),
+            (r" "                                           => Whitespace),
+            (r"+\u{200D}+=\u{200D}"                         => Identifier("+\u{200D}+=\u{200D}")),
+            (r" "                                           => Whitespace),
+            (r"f\u{}o"                                      => Identifier("f\u{FFFD}o")),
+            (r" "                                           => Whitespace),
+            (r"f\u{REPLACEMENT CHARACTER}o"                 => Identifier("f\u{FFFD}o")),
+            (r"+\uD900\uDDDD"                               => Identifier("+\u{FFFD}\u{FFFD}")),
+            (r"_\u{9999999999999999}_"                      => Identifier("_\u{FFFD}_"));
+
+        Severity::Error:
+            (  1,   9), ( 11,  19), ( 20,  26), ( 30,  36), ( 37,  38), ( 45,  46), ( 51,  59),
+            ( 63,  71), ( 74,  82), ( 83,  91), ( 93, 101), (103, 111), (115, 117), (120, 145),
+            (149, 153), (147, 153), (155, 159), (153, 159), (160, 180);
+        }
     }
 
     #[test]
     fn identifier_unicode_ascii_escapes() {
-        check(&[
-            ScannerTestSlice(r"f\u{6F}o",                                   Token::Identifier),
-            ScannerTestSlice(r" ",                                          Token::Whitespace),
-            ScannerTestSlice(r"example\u{2E}com",                           Token::Identifier),
-            ScannerTestSlice(r" ",                                          Token::Whitespace),
-            ScannerTestSlice(r"\u{2E}\u{2E}\u{2E}",                         Token::Unrecognized),
-            ScannerTestSlice(r" ",                                          Token::Whitespace),
-            ScannerTestSlice(r"\u{2E}",                                     Token::Unrecognized),
-            ScannerTestSlice(r".",                                          Token::Dot),
-            ScannerTestSlice(r"\u{2E}",                                     Token::Unrecognized),
-            ScannerTestSlice(r" ",                                          Token::Whitespace),
-            ScannerTestSlice(r"c\u{31}2",                                   Token::Identifier),
-            ScannerTestSlice(r" ",                                          Token::Whitespace),
-            ScannerTestSlice(r"test\u{0020}test",                           Token::Identifier),
-            ScannerTestSlice(r" ",                                          Token::Whitespace),
-            ScannerTestSlice(r"a\u{2B}b",                                   Token::Identifier),
-            ScannerTestSlice(r" ",                                          Token::Whitespace),
-            ScannerTestSlice(r"*\u{3E}*",                                   Token::Identifier),
-            ScannerTestSlice(r" ",                                          Token::Whitespace),
-            ScannerTestSlice("\u{2045}\\u{60}",                             Token::Identifier),
-        ], &[
-            Span::new(  1,   7), Span::new( 16,  22), Span::new( 26,  44), Span::new( 45,  51),
-            Span::new( 52,  58), Span::new( 60,  66), Span::new( 72,  80), Span::new( 86,  92),
-            Span::new( 95, 101), Span::new(106, 112),
-        ], &[]);
+        check! {
+            (r"f\u{6F}o"                                    => Identifier("f\u{FFFD}o")),
+            (r" "                                           => Whitespace),
+            (r"example\u{2E}com"                            => Identifier("example\u{FFFD}com")),
+            (r" "                                           => Whitespace),
+            (r"\u{2E}\u{2E}\u{2E}"                          => Unrecognized),
+            (r" "                                           => Whitespace),
+            (r"\u{2E}"                                      => Unrecognized),
+            (r"."                                           => Dot),
+            (r"\u{2E}"                                      => Unrecognized),
+            (r" "                                           => Whitespace),
+            (r"c\u{31}2"                                    => Identifier("c\u{FFFD}2")),
+            (r" "                                           => Whitespace),
+            (r"test\u{0020}test"                            => Identifier("test\u{FFFD}test")),
+            (r" "                                           => Whitespace),
+            (r"a\u{2B}b"                                    => Identifier("a\u{FFFD}b")),
+            (r" "                                           => Whitespace),
+            (r"*\u{3E}*"                                    => Identifier("*\u{FFFD}*")),
+            (r" "                                           => Whitespace),
+            ("\u{2045}\\u{60}"                              => Identifier("\u{2045}\u{FFFD}"));
+
+        Severity::Error:
+            (  1,   7), ( 16,  22), ( 26,  44), ( 45,  51), ( 52,  58), ( 60,  66), ( 72,  80),
+            ( 86,  92), ( 95, 101), (106, 112);
+        }
     }
 
     #[test]
     fn identifier_invalid_quote_modifiers() {
-        check(&[
+        check! {
             // One peculiar case is usage of modifier characters after quote identifiers.
             // Instead of being reported as a separate Unrecognized token they are included
             // into the quote token (after getting reported, of course).
-            ScannerTestSlice("\u{2045}\u{0488}",                            Token::Identifier),
-            ScannerTestSlice("\u{276E}\u{0DDC}\u{16F7A}",                   Token::Identifier),
-            ScannerTestSlice("\u{0F3D}\u{200D}\u{20DD}",                    Token::Identifier),
-            ScannerTestSlice("\u{FE18}\u{093F}\u{0A3F}",                    Token::Identifier),
-            ScannerTestSlice("\u{00AB}\u{0324}\u{0483}",                    Token::Identifier),
-            ScannerTestSlice("\u{2039}\u{0CC7}",                            Token::Identifier),
-            ScannerTestSlice("\u{2019}\u{20E2}",                            Token::Identifier),
-            ScannerTestSlice("\u{2E0A}\u{17CA}\u{200C}\u{1B3C}",            Token::Identifier),
-        ], &[ Span::new( 3,  5), Span::new( 8, 11), Span::new(11, 15), Span::new(18, 21),
-              Span::new(21, 24), Span::new(27, 30), Span::new(30, 33), Span::new(35, 37),
-              Span::new(37, 39), Span::new(42, 45), Span::new(48, 51), Span::new(54, 57),
-              Span::new(57, 60), Span::new(60, 63),
-        ], &[]);
+            ("\u{2045}\u{0488}"                             => Identifier("\u{2045}\u{0488}")),
+            ("\u{276E}\u{0DDC}\u{16F7A}"                    => Identifier("\u{276E}\u{0DDC}\u{16F7A}")),
+            ("\u{0F3D}\u{200D}\u{20DD}"                     => Identifier("\u{0F3D}\u{200D}\u{20DD}")),
+            ("\u{FE18}\u{093F}\u{0A3F}"                     => Identifier("\u{FE18}\u{093F}\u{0A3F}")),
+            ("\u{00AB}\u{0324}\u{0483}"                     => Identifier("\u{00AB}\u{0324}\u{0483}")),
+            ("\u{2039}\u{0CC7}"                             => Identifier("\u{2039}\u{0CC7}")),
+            ("\u{2019}\u{20E2}"                             => Identifier("\u{2019}\u{20E2}")),
+            ("\u{2E0A}\u{17CA}\u{200C}\u{1B3C}"             => Identifier("\u{2E0A}\u{17CA}\u{200C}\u{1B3C}"));
+        Severity::Error:
+            ( 3,  5), ( 8, 11), (11, 15), (18, 21), (21, 24), (27, 30), (30, 33), (35, 37),
+            (37, 39), (42, 45), (48, 51), (54, 57), (57, 60), (60, 63);
+        }
     }
 
     #[test]
     fn identifier_special_raw_strings() {
-        check(&[
+        check! {
             // Raw strings start with an 'r' which is a valid starter of word identifiers.
             // We must not confuse them.
-            ScannerTestSlice("r\"awr\"",        Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",               Token::Whitespace),
-            ScannerTestSlice("ra",              Token::Identifier),
-            ScannerTestSlice("\"wr\"",          Token::Literal(Lit::String)),
-            ScannerTestSlice(" ",               Token::Whitespace),
-            ScannerTestSlice("raaaaa",          Token::Identifier),
-            ScannerTestSlice("#",               Token::Hash),
-            ScannerTestSlice("#",               Token::Hash),
-            ScannerTestSlice("\"wr\"",          Token::Literal(Lit::String)),
-            ScannerTestSlice("#",               Token::Hash),
-            ScannerTestSlice("#",               Token::Hash),
-            ScannerTestSlice(" ",               Token::Whitespace),
-            ScannerTestSlice("r#\"awr\"#",      Token::Literal(Lit::RawString)),
-        ], &[], &[]);
+            ("r\"awr\""         => Literal(RawString, "awr")),
+            (" "                => Whitespace),
+            ("ra"               => Identifier("ra")),
+            ("\"wr\""           => Literal(String, "wr")),
+            (" "                => Whitespace),
+            ("raaaaa"           => Identifier("raaaaa")),
+            ("#"                => Hash),
+            ("#"                => Hash),
+            ("\"wr\""           => Literal(String, "wr")),
+            ("#"                => Hash),
+            ("#"                => Hash),
+            (" "                => Whitespace),
+            ("r#\"awr\"#"       => Literal(RawString, "awr"));
+        }
     }
 
     // TODO: boundary tests between all token types
@@ -4031,259 +4199,261 @@ mod tests {
 
     #[test]
     fn symbol_implicit() {
-        check(&[
+        check! {
             // Implicit symbols are word identifiers followed by a single literal colon.
             // For example, ASCII words are fine:
-            ScannerTestSlice("foo:",                                        Token::ImplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("Symbol:",                                     Token::ImplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("_:",                                          Token::ImplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("_1:",                                         Token::ImplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
+            ("foo:"                                         => ImplicitSymbol("foo")),
+            (" "                                            => Whitespace),
+            ("Symbol:"                                      => ImplicitSymbol("Symbol")),
+            (" "                                            => Whitespace),
+            ("_:"                                           => ImplicitSymbol("_")),
+            (" "                                            => Whitespace),
+            ("_1:"                                          => ImplicitSymbol("_1")),
+            (" "                                            => Whitespace),
             // Unicode words are fine too:
-            ScannerTestSlice("\u{691C}\u{67FB}:",                           Token::ImplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{1FAA}:",                                   Token::ImplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{3007}\u{3007}\u{3007}:",                   Token::ImplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{212E}\u{2118}:",                           Token::ImplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{09A6}\u{09C0}\u{09B0}\u{09CD}\u{0998}:",   Token::ImplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
+            ("\u{691C}\u{67FB}:"                            => ImplicitSymbol("\u{691C}\u{67FB}")),
+            (" "                                            => Whitespace),
+            ("\u{1FAA}:"                                    => ImplicitSymbol("\u{1FAA}")),
+            (" "                                            => Whitespace),
+            ("\u{3007}\u{3007}\u{3007}:"                    => ImplicitSymbol("\u{3007}\u{3007}\u{3007}")),
+            (" "                                            => Whitespace),
+            ("\u{212E}\u{2118}:"                            => ImplicitSymbol("\u{212E}\u{2118}")),
+            (" "                                            => Whitespace),
+            ("\u{09A6}\u{09C0}\u{09B0}\u{09CD}\u{0998}:"    => ImplicitSymbol("\u{09A6}\u{09C0}\u{09B0}\u{09CD}\u{0998}")),
+            (" "                                            => Whitespace),
             // As well as escaped ones:
-            ScannerTestSlice("\u{005F}\\u{0661}\\u{0665}:",                 Token::ImplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{005F}\\u{FE4F}\u{005F}:",                  Token::ImplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{0078}\\u{19DA}:",                          Token::ImplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\\u{0915}\u{094D}\\u{0937}:",                 Token::ImplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\\u{1FAA}:",                                  Token::ImplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-        ], &[], &[]);
+            ("\u{005F}\\u{0661}\\u{0665}:"                  => ImplicitSymbol("\u{005F}\u{0661}\u{0665}")),
+            (" "                                            => Whitespace),
+            ("\u{005F}\\u{FE4F}\u{005F}:"                   => ImplicitSymbol("\u{005F}\u{FE4F}\u{005F}")),
+            (" "                                            => Whitespace),
+            ("\u{0078}\\u{19DA}:"                           => ImplicitSymbol("\u{0078}\u{19DA}")),
+            (" "                                            => Whitespace),
+            ("\\u{0915}\u{094D}\\u{0937}:"                  => ImplicitSymbol("\u{0915}\u{094D}\u{0937}")),
+            (" "                                            => Whitespace),
+            ("\\u{1FAA}:"                                   => ImplicitSymbol("\u{1FAA}")),
+            (" "                                            => Whitespace);
+        }
     }
 
     #[test]
     fn symbol_implicit_boundaries() {
-        check(&[
+        check! {
             // Only a single colon forms a boundary for a symbol. It can be followed by anything
             // except for another colon, in which case we see a word identifier followed by
             // a double colon.
-            ScannerTestSlice("foo:",                                        Token::ImplicitSymbol),
-            ScannerTestSlice("+",                                           Token::Identifier),
-            ScannerTestSlice("bar",                                         Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("x:",                                          Token::ImplicitSymbol),
-            ScannerTestSlice("\n",                                          Token::Whitespace),
-            ScannerTestSlice("y:",                                          Token::ImplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("z:",                                          Token::ImplicitSymbol),
-            ScannerTestSlice("':'",                                         Token::Literal(Lit::Character)),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("_:",                                          Token::ImplicitSymbol),
-            ScannerTestSlice("10",                                          Token::Literal(Lit::Integer)),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("zork",                                        Token::Identifier),
-            ScannerTestSlice("::",                                          Token::Dualcolon),
-            ScannerTestSlice("x",                                           Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
+            ("foo:"                                 => ImplicitSymbol("foo")),
+            ("+"                                    => Identifier("+")),
+            ("bar"                                  => Identifier("bar")),
+            (" "                                    => Whitespace),
+            ("x:"                                   => ImplicitSymbol("x")),
+            ("\n"                                   => Whitespace),
+            ("y:"                                   => ImplicitSymbol("y")),
+            (" "                                    => Whitespace),
+            ("z:"                                   => ImplicitSymbol("z")),
+            ("':'"                                  => Literal(Character, ":")),
+            (" "                                    => Whitespace),
+            ("_:"                                   => ImplicitSymbol("_")),
+            ("10"                                   => Literal(Integer, "10")),
+            (" "                                    => Whitespace),
+            ("zork"                                 => Identifier("zork")),
+            ("::"                                   => Dualcolon),
+            ("x"                                    => Identifier("x")),
+            (" "                                    => Whitespace),
             // Also, only word identifiers can be implicit symbols
-            ScannerTestSlice("++",                                          Token::Identifier),
-            ScannerTestSlice(":",                                           Token::Colon),
-            ScannerTestSlice("$",                                           Token::Identifier),
-            ScannerTestSlice(":",                                           Token::Colon),
-            ScannerTestSlice(";",                                           Token::Semicolon),
-            ScannerTestSlice(":",                                           Token::Colon),
-            ScannerTestSlice("[",                                           Token::OpenDelim(Delimiter::Bracket)),
-            ScannerTestSlice(":",                                           Token::Colon),
-            ScannerTestSlice("]",                                           Token::CloseDelim(Delimiter::Bracket)),
-            ScannerTestSlice("\u{2025}",                                    Token::Identifier),
-            ScannerTestSlice(":",                                           Token::Colon),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\u{0024}\u{0488}",                            Token::Identifier),
-            ScannerTestSlice(":",                                           Token::Colon),
-            ScannerTestSlice("\u{FE18}",                                    Token::Identifier),
-            ScannerTestSlice(":",                                           Token::Colon),
-            ScannerTestSlice("\u{300E}",                                    Token::Identifier),
+            ("++"                                   => Identifier("++")),
+            (":"                                    => Colon),
+            ("$"                                    => Identifier("$")),
+            (":"                                    => Colon),
+            (";"                                    => Semicolon),
+            (":"                                    => Colon),
+            ("["                                    => OpenDelim(Bracket)),
+            (":"                                    => Colon),
+            ("]"                                    => CloseDelim(Bracket)),
+            ("\u{2025}"                             => Identifier("\u{2025}")),
+            (":"                                    => Colon),
+            (" "                                    => Whitespace),
+            ("\u{0024}\u{0488}"                     => Identifier("\u{0024}\u{0488}")),
+            (":"                                    => Colon),
+            ("\u{FE18}"                             => Identifier("\u{FE18}")),
+            (":"                                    => Colon),
+            ("\u{300E}"                             => Identifier("\u{300E}")),
             // This includes escaped identifiers
-            ScannerTestSlice("\u{220F}\\u{2230}",                           Token::Identifier),
-            ScannerTestSlice(":",                                           Token::Colon),
-            ScannerTestSlice("\u{19FB}\u{19FF}",                            Token::Identifier),
-            ScannerTestSlice(":",                                           Token::Colon),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\\u{26B5}\\u{1D1E7}",                         Token::Identifier),
-            ScannerTestSlice("::",                                          Token::Dualcolon),
-            ScannerTestSlice("\\u{2E02}",                                   Token::Identifier),
-            ScannerTestSlice(":",                                           Token::Colon),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("\\u{2E21}",                                   Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
+            ("\u{220F}\\u{2230}"                    => Identifier("\u{220F}\u{2230}")),
+            (":"                                    => Colon),
+            ("\u{19FB}\u{19FF}"                     => Identifier("\u{19FB}\u{19FF}")),
+            (":"                                    => Colon),
+            (" "                                    => Whitespace),
+            ("\\u{26B5}\\u{1D1E7}"                  => Identifier("\u{26B5}\u{1D1E7}")),
+            ("::"                                   => Dualcolon),
+            ("\\u{2E02}"                            => Identifier("\u{2E02}")),
+            (":"                                    => Colon),
+            (" "                                    => Whitespace),
+            ("\\u{2E21}"                            => Identifier("\u{2E21}")),
+            (" "                                    => Whitespace),
             // Finally, implicit symbols do not allow type suffixes
-            ScannerTestSlice("foo:",                                        Token::ImplicitSymbol),
-            ScannerTestSlice("bar",                                         Token::Identifier),
-            ScannerTestSlice("::",                                          Token::Dualcolon),
-            ScannerTestSlice("baz:",                                        Token::ImplicitSymbol),
-            ScannerTestSlice("_",                                           Token::Identifier),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
+            ("foo:"                                 => ImplicitSymbol("foo")),
+            ("bar"                                  => Identifier("bar")),
+            ("::"                                   => Dualcolon),
+            ("baz:"                                 => ImplicitSymbol("baz")),
+            ("_"                                    => Identifier("_")),
+            (" "                                    => Whitespace),
             // And cannot 'steal' others' suffixes
-            ScannerTestSlice("123foo",                                      Token::Literal(Lit::Integer)),
-            ScannerTestSlice(":",                                           Token::Colon),
-            ScannerTestSlice("bar:",                                        Token::ImplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("'x'x",                                        Token::Literal(Lit::Character)),
-            ScannerTestSlice("::",                                          Token::Dualcolon),
-            ScannerTestSlice("y",                                           Token::Identifier),
-        ], &[], &[]);
+            ("123foo"                               => Literal(Integer, "123", "foo")),
+            (":"                                    => Colon),
+            ("bar:"                                 => ImplicitSymbol("bar")),
+            (" "                                    => Whitespace),
+            ("'x'x"                                 => Literal(Character, "x", "x")),
+            ("::"                                   => Dualcolon),
+            ("y"                                    => Identifier("y"));
+        }
     }
 
     #[test]
     fn symbol_implicit_invalid_characters() {
-        check(&[
+        check! {
             // Invalid Unicode escapes and characters in symbols are reported as usual
-            ScannerTestSlice("a\\u{0488}b:",                                Token::ImplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("a\u{0488}b:",                                 Token::ImplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("example\\u{2E}com:",                          Token::ImplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("f\\u{REPLACEMENT CHARACTER}o:",               Token::ImplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("w\\u2113\\u1d466d:",                          Token::ImplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("C\u{20DD}_\u{20E3}:",                         Token::ImplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("test\\u{003A}:",                              Token::ImplicitSymbol),
-        ], &[ Span::new(  1,   9), Span::new( 13,  15), Span::new( 25,  31), Span::new( 37,  62),
-              Span::new( 68,  72), Span::new( 74,  80), Span::new( 72,  80), Span::new( 83,  86),
-              Span::new( 87,  90), Span::new( 96, 104),
-        ], &[]);
+            ("a\\u{0488}b:"                                 => ImplicitSymbol("a\u{0488}b")),
+            (" "                                            => Whitespace),
+            ("a\u{0488}b:"                                  => ImplicitSymbol("a\u{0488}b")),
+            (" "                                            => Whitespace),
+            ("example\\u{2E}com:"                           => ImplicitSymbol("example\u{FFFD}com")),
+            (" "                                            => Whitespace),
+            ("f\\u{REPLACEMENT CHARACTER}o:"                => ImplicitSymbol("f\u{FFFD}o")),
+            (" "                                            => Whitespace),
+            ("w\\u2113\\u1d466d:"                           => ImplicitSymbol("w\u{2113}\u{FFFD}")),
+            (" "                                            => Whitespace),
+            ("C\u{20DD}_\u{20E3}:"                          => ImplicitSymbol("C\u{20DD}_\u{20E3}")),
+            (" "                                            => Whitespace),
+            ("test\\u{003A}:"                               => ImplicitSymbol("test\u{FFFD}"));
+
+        Severity::Error:
+            (  1,   9), ( 13,  15), ( 25,  31), ( 37,  62), ( 68,  72), ( 74,  80), ( 72,  80),
+            ( 83,  86), ( 87,  90), ( 96, 104);
+        }
     }
 
     #[test]
     fn symbol_explicit() {
-        check(&[
-            // Explicit symbols look like strings quoted with backquotes
-            ScannerTestSlice("`foo`",                                       Token::ExplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("`one two three`",                             Token::ExplicitSymbol),
-            ScannerTestSlice("`1-2-3`",                                     Token::ExplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("`'\"'`",                                      Token::ExplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("``",                                          Token::ExplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
+        check! {
+            // Explicit symbols look like strings quoted with backquote,
+            ("`foo`"                                        => ExplicitSymbol("foo")),
+            (" "                                            => Whitespace),
+            ("`one two three`"                              => ExplicitSymbol("one two three")),
+            ("`1-2-3`"                                      => ExplicitSymbol("1-2-3")),
+            (" "                                            => Whitespace),
+            ("`'\"'`"                                       => ExplicitSymbol("'\"'")),
+            (" "                                            => Whitespace),
+            ("``"                                           => ExplicitSymbol("")),
+            (" "                                            => Whitespace),
             // They can contain Unicode and support all character escape sequences,
             // plus an additional escape sequence for the backquote character
-            ScannerTestSlice("`\\0\\t\\r\\n\\\\\\\"`",                      Token::ExplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("`\u{3053}\u{3093}\u{306B}\u{3061}\u{306F}`",  Token::ExplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("`\\u{05E9}\\u{05DC}\\u{05D5}\\u{05DD}`",      Token::ExplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("`\x00\x32`",                                  Token::ExplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("`///*//*/`",                                  Token::ExplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("`\\`...\\``",                                 Token::ExplicitSymbol),
-        ], &[], &[]);
+            ("`\\0\\t\\r\\n\\\\\\\"`"                       => ExplicitSymbol("\0\t\r\n\\\"")),
+            (" "                                            => Whitespace),
+            ("`\u{3053}\u{3093}\u{306B}\u{3061}\u{306F}`"   => ExplicitSymbol("\u{3053}\u{3093}\u{306B}\u{3061}\u{306F}")),
+            (" "                                            => Whitespace),
+            ("`\\u{05E9}\\u{05DC}\\u{05D5}\\u{05DD}`"       => ExplicitSymbol("\u{05E9}\u{05DC}\u{05D5}\u{05DD}")),
+            (" "                                            => Whitespace),
+            ("`\x00\x32`"                                   => ExplicitSymbol("\x00\x32")),
+            (" "                                            => Whitespace),
+            ("`///*//*/`"                                   => ExplicitSymbol("///*//*/")),
+            (" "                                            => Whitespace),
+            ("`\\`...\\``"                                  => ExplicitSymbol("`...`"));
+        }
     }
 
     #[test]
     fn symbol_explicit_invalid_escapes() {
-        check(&[
-            // Invalid escape sequences in explicit symbols are reported as in string literals
-            ScannerTestSlice(r"`\u{123\u456}\u{testing...}`",               Token::ExplicitSymbol),
-            ScannerTestSlice(r" ",                                          Token::Whitespace),
-            ScannerTestSlice(r"`\uguu\uDEAD\uF0F0F0F0F0F0F0F0\u`",          Token::ExplicitSymbol),
-            ScannerTestSlice(r" ",                                          Token::Whitespace),
-            ScannerTestSlice(r"`\a\b\f\v\?\'`",                             Token::ExplicitSymbol),
-            ScannerTestSlice(r" ",                                          Token::Whitespace),
-            ScannerTestSlice(r"`\x\x1\x1234`",                              Token::ExplicitSymbol),
-        ], &[ Span::new( 7,  7), Span::new( 9,  9), Span::new(13, 27), Span::new(32, 32),
-              Span::new(37, 41), Span::new(35, 41), Span::new(43, 59), Span::new(41, 59),
-              Span::new(61, 61), Span::new(64, 66), Span::new(66, 68), Span::new(68, 70),
-              Span::new(70, 72), Span::new(72, 74), Span::new(74, 76), Span::new(79, 81),
-              Span::new(81, 84), Span::new(84, 90),
-        ], &[]);
+        check! {
+            // Invalid escape sequences in explicit symbols are reported as in string literal
+            (r"`\u{123\u456}\u{testing...}`"                => ExplicitSymbol("\u{123}\u{456}\u{FFFD}")),
+            (r" "                                           => Whitespace),
+            (r"`\uguu\uDEAD\uF0F0F0F0F0F0F0F0\u`"           => ExplicitSymbol("\u{FFFD}guu\u{FFFD}\u{FFFD}\u{FFFD}")),
+            (r" "                                           => Whitespace),
+            (r"`\a\b\f\v\?\'`"                              => ExplicitSymbol("abfv?'")),
+            (r" "                                           => Whitespace),
+            (r"`\x\x1\x1234`"                               => ExplicitSymbol("\u{FFFD}\u{FFFD}\u{FFFD}"));
+
+        Severity::Error:
+            ( 7,  7), ( 9,  9), (13, 27), (32, 32), (37, 41), (35, 41), (43, 59), (41, 59),
+            (61, 61), (64, 66), (66, 68), (68, 70), (70, 72), (72, 74), (74, 76), (79, 81),
+            (81, 84), (84, 90);
+        }
     }
 
     #[test]
     fn symbol_explicit_invalid_mulitline() {
-        check(&[
+        check! {
             // Explicit symbols cannot span multiple lines. They are handled similar to character
             // literals. Though, one can embed newline characters into them via escape sequences.
-            ScannerTestSlice("`example",                                    Token::Unrecognized),
-            ScannerTestSlice("\n",                                          Token::Whitespace),
-            ScannerTestSlice("`some more",                                  Token::Unrecognized),
-            ScannerTestSlice("\r\n",                                        Token::Whitespace),
-            ScannerTestSlice("`Old\rApple`",                                Token::ExplicitSymbol),
-            ScannerTestSlice("`",                                           Token::Unrecognized),
-            ScannerTestSlice("\n",                                          Token::Whitespace),
-            ScannerTestSlice("`",                                           Token::Unrecognized),
-            ScannerTestSlice("\r\n",                                        Token::Whitespace),
-            ScannerTestSlice("`\r`",                                        Token::ExplicitSymbol),
-            ScannerTestSlice("\n",                                          Token::Whitespace),
-            ScannerTestSlice("`\\",                                         Token::Unrecognized),
-            ScannerTestSlice("\n\t",                                        Token::Whitespace),
-            ScannerTestSlice("`\\",                                         Token::Unrecognized),
-            ScannerTestSlice("\r\n",                                        Token::Whitespace),
-            ScannerTestSlice("`\\\r`",                                      Token::ExplicitSymbol),
-            ScannerTestSlice("\t",                                          Token::Whitespace),
-            ScannerTestSlice("test",                                        Token::Identifier),
-            ScannerTestSlice("`",                                           Token::Unrecognized),
-        ], &[
-            Span::new(25, 26), Span::new(38, 39), Span::new(51, 52), Span::new(50, 52),
-        ], &[
-            Span::new( 0,  8), Span::new( 9, 19), Span::new(32, 33), Span::new(34, 35),
-            Span::new(41, 43), Span::new(45, 47), Span::new(58, 59),
-        ]);
+            ("`example"                                     => Unrecognized),
+            ("\n"                                           => Whitespace),
+            ("`some more"                                   => Unrecognized),
+            ("\r\n"                                         => Whitespace),
+            ("`Old\rApple`"                                 => ExplicitSymbol("Old\rApple")),
+            ("`"                                            => Unrecognized),
+            ("\n"                                           => Whitespace),
+            ("`"                                            => Unrecognized),
+            ("\r\n"                                         => Whitespace),
+            ("`\r`"                                         => ExplicitSymbol("\r")),
+            ("\n"                                           => Whitespace),
+            ("`\\"                                          => Unrecognized),
+            ("\n\t"                                         => Whitespace),
+            ("`\\"                                          => Unrecognized),
+            ("\r\n"                                         => Whitespace),
+            ("`\\\r`"                                       => ExplicitSymbol("\r")),
+            ("\t"                                           => Whitespace),
+            ("test"                                         => Identifier("test")),
+            ("`"                                            => Unrecognized);
+
+        Severity::Error:
+            (25, 26), (38, 39), (51, 52), (50, 52);
+
+        Severity::Fatal:
+            ( 0,  8), ( 9, 19), (32, 33), (34, 35), (41, 43), (45, 47), (58, 59);
+        }
     }
 
     #[test]
     fn symbol_explicit_premature_termination() {
         // Unexpected EOFs are handled similar to characters and strings
-        check(&[ ScannerTestSlice("`",      Token::Unrecognized) ], &[], &[ Span::new(0, 1) ]);
-        check(&[ ScannerTestSlice("`xyz",   Token::Unrecognized) ], &[], &[ Span::new(0, 4) ]);
-        check(&[ ScannerTestSlice("`\\x",   Token::Unrecognized) ], &[ Span::new(1, 3) ],
-                                                                    &[ Span::new(0, 3) ]);
-        check(&[ ScannerTestSlice("`\\u",   Token::Unrecognized) ], &[ Span::new(3, 3) ],
-                                                                    &[ Span::new(0, 3) ]);
-        check(&[ ScannerTestSlice("`\\u{1", Token::Unrecognized) ], &[ Span::new(5, 5) ],
-                                                                    &[ Span::new(0, 5) ]);
+        check! { ("`"      => Unrecognized); Severity::Fatal: (0, 1); }
+        check! { ("`xyz"   => Unrecognized); Severity::Fatal: (0, 4); }
+        check! { ("`\\x"   => Unrecognized); Severity::Error: (1, 3);
+                                             Severity::Fatal: (0, 3); }
+        check! { ("`\\u"   => Unrecognized); Severity::Error: (3, 3);
+                                             Severity::Fatal: (0, 3); }
+        check! { ("`\\u{1" => Unrecognized); Severity::Error: (5, 5);
+                                             Severity::Fatal: (0, 5); }
     }
 
     #[test]
     fn symbol_explicit_no_type_suffixes() {
-        check(&[
+        check! {
             // Explicit symbols do not have type suffixes. They are terminated right after the
             // backquote.
-            ScannerTestSlice("`foo`",                                       Token::ExplicitSymbol),
-            ScannerTestSlice("bar",                                         Token::Identifier),
-            ScannerTestSlice("`baz`",                                       Token::ExplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("`o`",                                         Token::ExplicitSymbol),
-            ScannerTestSlice("r\"a\"",                                      Token::Literal(Lit::RawString)),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("`x`",                                         Token::ExplicitSymbol),
-            ScannerTestSlice("'y'",                                         Token::Literal(Lit::Character)),
-            ScannerTestSlice("\"z\"",                                       Token::Literal(Lit::String)),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("``",                                          Token::ExplicitSymbol),
-            ScannerTestSlice("+",                                           Token::Identifier),
-            ScannerTestSlice("``",                                          Token::ExplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("`.`",                                         Token::ExplicitSymbol),
-            ScannerTestSlice(".",                                           Token::Dot),
-            ScannerTestSlice("`.`",                                         Token::ExplicitSymbol),
-            ScannerTestSlice(" ",                                           Token::Whitespace),
-            ScannerTestSlice("`:`",                                         Token::ExplicitSymbol),
-            ScannerTestSlice(":",                                           Token::Colon),
-            ScannerTestSlice("e",                                           Token::Identifier),
-        ], &[], &[]);
+            ("`foo`"        => ExplicitSymbol("foo")),
+            ("bar"          => Identifier("bar")),
+            ("`baz`"        => ExplicitSymbol("baz")),
+            (" "            => Whitespace),
+            ("`o`"          => ExplicitSymbol("o")),
+            ("r\"a\""       => Literal(RawString, "a")),
+            (" "            => Whitespace),
+            ("`x`"          => ExplicitSymbol("x")),
+            ("'y'"          => Literal(Character, "y")),
+            ("\"z\""        => Literal(String, "z")),
+            (" "            => Whitespace),
+            ("``"           => ExplicitSymbol("")),
+            ("+"            => Identifier("+")),
+            ("``"           => ExplicitSymbol("")),
+            (" "            => Whitespace),
+            ("`.`"          => ExplicitSymbol(".")),
+            ("."            => Dot),
+            ("`.`"          => ExplicitSymbol(".")),
+            (" "            => Whitespace),
+            ("`:`"          => ExplicitSymbol(":")),
+            (":"            => Colon),
+            ("e"            => Identifier("e"));
+        }
     }
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -4293,6 +4463,12 @@ mod tests {
     use std::rc::Rc;
 
     struct ScannerTestSlice<'a>(&'a str, Token);
+
+    struct ScannerTestResults {
+        pub tokens: Vec<ScannedToken>,
+        pub fatals: Vec<Span>,
+        pub errors: Vec<Span>,
+    }
 
     struct SinkReporter {
         pub diagnostics: Rc<RefCell<Vec<(Severity, Span)>>>,
@@ -4317,19 +4493,22 @@ mod tests {
 
     /// Checks whether a sequence of test string slices yields consistent results and generates
     /// expected diagnostics.
-    fn check(slices: &[ScannerTestSlice], expected_errors: &[Span], expected_fatals: &[Span]) {
-        let (test_string, expected_tokens) = expand_test_slices(slices);
+    fn check(slices: &[ScannerTestSlice], diagnostics: &[(Severity, Span)], pool: InternPool) {
+        let (test_string, expected) = preprocess_expected_data(slices, diagnostics);
 
-        let (actual_tokens, actual_fatals, actual_errors) = process_test_string(&test_string);
+        let actual = process_test_string(&test_string, &pool);
 
         let token_failures =
-            verify("Tokens", &test_string, &expected_tokens, &actual_tokens, token_as_str);
+            verify("Tokens", &expected.tokens, &actual.tokens,
+                |tok| print_token(tok, &test_string, &pool));
 
         let fatal_failures =
-            verify("Fatal errors", &test_string, expected_fatals, &actual_fatals, span_as_str);
+            verify("Fatal errors", &expected.fatals, &actual.fatals,
+                |span| print_span(span, &test_string));
 
         let error_failures =
-            verify("Errors", &test_string, expected_errors, &actual_errors, span_as_str);
+            verify("Errors", &expected.errors, &actual.errors,
+                |span| print_span(span, &test_string));
 
         if let Some(first_failure) = token_failures {
             panic!("first invalid token: #{}", first_failure);
@@ -4342,6 +4521,20 @@ mod tests {
         if let Some(first_failure) = error_failures {
             panic!("first invalid error: #{}", first_failure);
         }
+    }
+
+    /// Reorder and rearrange raw test data into the input string and expected results.
+    fn preprocess_expected_data(slices: &[ScannerTestSlice], diagnostics: &[(Severity, Span)])
+        -> (String, ScannerTestResults)
+    {
+        let (test_string, tokens) = expand_test_slices(slices);
+        let (fatals, errors) = partition_diagnostics(diagnostics);
+
+        (test_string, ScannerTestResults {
+            tokens: tokens,
+            fatals: fatals,
+            errors: errors,
+        })
     }
 
     /// Preprocesses test slices, returning the whole string to be scanned over
@@ -4367,13 +4560,13 @@ mod tests {
 
     /// Performs actual scanning of the `whole_string`, producing a list of resulting tokens
     /// and a number of diagnostics which were emitted during scanning.
-    fn process_test_string(whole_string: &str) -> (Vec<ScannedToken>, Vec<Span>, Vec<Span>) {
+    fn process_test_string(whole_string: &str, pool: &InternPool) -> ScannerTestResults {
         let mut tokens = Vec::new();
         let diagnostics = Rc::new(RefCell::new(Vec::new()));
         let reporter = SinkReporter::new(diagnostics.clone());
         let handler = SpanReporter::with_reporter(Box::new(reporter));
 
-        let mut scanner = StringScanner::new(whole_string, &handler);
+        let mut scanner = StringScanner::new(whole_string, pool, &handler);
 
         // Loop with postcondition to catch the EOF token
         loop {
@@ -4390,28 +4583,47 @@ mod tests {
 
         let (fatals, errors) = partition_diagnostics(&diagnostics.borrow()[..]);
 
-        return (tokens, fatals, errors);
+        return ScannerTestResults {
+            tokens: tokens,
+            fatals: fatals,
+            errors: errors,
+        };
     }
 
     /// Partitions diagnostics by severity.
-    fn partition_diagnostics(diags: &[(Severity, Span)]) -> (Vec<Span>, Vec<Span>) {
+    fn partition_diagnostics(diagnostics: &[(Severity, Span)]) -> (Vec<Span>, Vec<Span>) {
+        use std::cmp;
+
         let mut fatals = Vec::new();
         let mut errors = Vec::new();
 
-        for &(severity, span) in diags {
+        for &(severity, span) in diagnostics {
             match severity {
                 Severity::Fatal => fatals.push(span),
                 Severity::Error => errors.push(span),
             }
         }
 
+        fn span_position(lhs: &Span, rhs: &Span) -> cmp::Ordering {
+            if lhs.from < rhs.from {
+                return cmp::Ordering::Less;
+            }
+            if lhs.from > rhs.from {
+                return cmp::Ordering::Greater;
+            }
+            return lhs.to.cmp(&rhs.to);
+        }
+
+        fatals.sort_by(span_position);
+        errors.sort_by(span_position);
+
         return (fatals, errors);
     }
 
     /// Prints out and verifies produced results. Returns Some 1-based index of the first incorrect
     /// item, or None if the actual results are equal to expected ones.
-    fn verify<T, F>(title: &str, s: &str, expected: &[T], actual: &[T], as_str: F) -> Option<u32>
-        where T: Eq, F: Fn(&str, &T) -> String
+    fn verify<T, F>(title: &str, expected: &[T], actual: &[T], to_string: F) -> Option<u32>
+        where T: Eq, F: Fn(&T) -> String
     {
         if expected.is_empty() && actual.is_empty() {
             return None;
@@ -4432,29 +4644,59 @@ mod tests {
                 index     = index,
                 ind_ex    = if bad { "-- exp:" } else { "" },
                 ind_act   = if bad { "-- act:" } else { "" },
-                expected  = expected.map_or("None".to_string(), |v| as_str(s, v)),
-                actual    = actual.  map_or("None".to_string(), |v| as_str(s, v)),
+                expected  = expected.map_or("None".to_string(), &to_string),
+                actual    = actual.  map_or("None".to_string(), &to_string),
             );
         }
 
         return first_mismatch;
     }
 
-    fn token_as_str(s: &str, token: &ScannedToken) -> String {
-        format!("{token:?} {slice:?} @ [{from}, {to}]",
-            token = token.tok,
-            slice = &s[token.span.from..token.span.to],
+    fn print_token(token: &ScannedToken, buf: &str, pool: &InternPool) -> String {
+        format!("{token} @ [{from}, {to}] = {slice:?}",
+            token = pretty_print_token(&token.tok, pool),
             from  = token.span.from,
             to    = token.span.to,
+            slice = &buf[token.span.from..token.span.to],
         )
     }
 
-    fn span_as_str(s: &str, span: &Span) -> String {
-        format!("{slice:?} @ [{from}, {to}]",
-            slice = &s[span.from..span.to],
+    fn print_span(span: &Span, buf: &str) -> String {
+        format!("[{from}, {to}] = {slice:?}",
             from  = span.from,
             to    = span.to,
+            slice = &buf[span.from..span.to],
         )
+    }
+
+    fn pretty_print_token(token: &Token, pool: &InternPool) -> String {
+        match *token {
+            Token::DocComment(_) => "DocComment".to_string(),
+
+            Token::Identifier(atom)     => format!("Identifier({:?})",     pool.get(atom)),
+            Token::ImplicitSymbol(atom) => format!("ImplicitSymbol({:?})", pool.get(atom)),
+            Token::ExplicitSymbol(atom) => format!("ExplicitSymbol({:?})", pool.get(atom)),
+
+            Token::Literal(ref lit, ref suffix) => pretty_print_literal(lit, suffix, pool),
+
+            _ => format!("{:?}", token)
+        }
+    }
+
+    fn pretty_print_literal(lit: &Lit, suffix: &Option<Atom>, pool: &InternPool) -> String {
+        let expr = match *lit {
+            Lit::Integer(atom)   => format!("Integer({:?})",   pool.get(atom)),
+            Lit::Float(atom)     => format!("Float({:?})",     pool.get(atom)),
+            Lit::Character(atom) => format!("Character({:?})", pool.get(atom)),
+            Lit::String(atom)    => format!("String({:?})",    pool.get(atom)),
+            Lit::RawString(atom) => format!("RawString({:?})", pool.get(atom)),
+        };
+
+        if let &Some(atom) = suffix {
+            format!("Literal({}, '{}')", expr, pool.get(atom))
+        } else {
+            format!("Literal({})", expr)
+        }
     }
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -13,5 +13,6 @@
 extern crate unicode;
 
 pub mod diagnostics;
+pub mod intern_pool;
 pub mod lexer;
 pub mod tokens;

--- a/src/libsyntax/tokens.rs
+++ b/src/libsyntax/tokens.rs
@@ -23,23 +23,11 @@ pub enum Token {
     /// Documentation comment.
     DocComment,
 
-    /// Left (opening) parenthesis `(`.
-    Lparen,
+    /// An opening (left) delimiter.
+    OpenDelim(Delimiter),
 
-    /// Right (closing) parenthesis `)`.
-    Rparen,
-
-    /// Left (opening) bracket `[`.
-    Lbrack,
-
-    /// Right (closing) bracket `]`.
-    Rbrack,
-
-    /// Left (opening) brace `{`.
-    Lbrace,
-
-    /// Right (closing) brace `}`.
-    Rbrace,
+    /// A closing (right) delimiter.
+    CloseDelim(Delimiter),
 
     /// Dot `.`.
     Dot,
@@ -59,6 +47,38 @@ pub enum Token {
     /// Hash `#`.
     Hash,
 
+    /// A literal value.
+    Literal(Lit),
+
+    /// An identifier (of any kind).
+    Identifier,
+
+    /// An implicit symbol.
+    ImplicitSymbol,
+
+    /// An explicit symbol.
+    ExplicitSymbol,
+
+    /// Marker token denoting invalid character sequences.
+    Unrecognized,
+}
+
+/// Delimiter type.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Delimiter {
+    /// Parentheses `( )`.
+    Paren,
+
+    /// Brackets `[ ]`.
+    Bracket,
+
+    /// Braces `{ }`.
+    Brace,
+}
+
+/// Literal token type.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Lit {
     /// An integer literal.
     Integer,
 
@@ -73,16 +93,4 @@ pub enum Token {
 
     /// A raw string of characters.
     RawString,
-
-    /// An identifier (of any kind).
-    Identifier,
-
-    /// An implicit symbol.
-    ImplicitSymbol,
-
-    /// An explicit symbol.
-    ExplicitSymbol,
-
-    /// Marker token denoting invalid character sequences.
-    Unrecognized,
 }

--- a/src/libsyntax/tokens.rs
+++ b/src/libsyntax/tokens.rs
@@ -8,6 +8,8 @@
 //!
 //! This module contains definitions of various tokens recognized and processed by Sash parser.
 
+use intern_pool::Atom;
+
 /// Types of tokens recognized by the scanner.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Token {
@@ -21,7 +23,7 @@ pub enum Token {
     Comment,
 
     /// Documentation comment.
-    DocComment,
+    DocComment(Atom),
 
     /// An opening (left) delimiter.
     OpenDelim(Delimiter),
@@ -48,16 +50,16 @@ pub enum Token {
     Hash,
 
     /// A literal value.
-    Literal(Lit),
+    Literal(Lit, Option<Atom>),
 
     /// An identifier (of any kind).
-    Identifier,
+    Identifier(Atom),
 
     /// An implicit symbol.
-    ImplicitSymbol,
+    ImplicitSymbol(Atom),
 
     /// An explicit symbol.
-    ExplicitSymbol,
+    ExplicitSymbol(Atom),
 
     /// Marker token denoting invalid character sequences.
     Unrecognized,
@@ -80,17 +82,17 @@ pub enum Delimiter {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Lit {
     /// An integer literal.
-    Integer,
+    Integer(Atom),
 
     /// A floating-point literal.
-    Float,
+    Float(Atom),
 
     /// A single character.
-    Character,
+    Character(Atom),
 
     /// A string of characters.
-    String,
+    String(Atom),
 
     /// A raw string of characters.
-    RawString,
+    RawString(Atom),
 }


### PR DESCRIPTION
This implements some improvements from #1, and revives some of them too:
- string interner for efficient storage of strings
- tokens get more context (as interned strings)
- identifiers, symbols, strings, and characters are interpreted (escape sequences are expanded)
- a macro appears to lower the amout of syntactical boilerplate in unit-tests
