### PR TITLE
Miscellaneous cleanup

### DIFF
--- a/src/libsyntax/lexer.rs
+++ b/src/libsyntax/lexer.rs
@@ -767,8 +767,8 @@ impl<'a> StringScanner<'a> {
                 return Ok('\n');
             }
             Some('\r') if self.peek_is('\n') => {
-                self.read(); // TODO: this may cause issues if read() is taught to skip over
-                self.read(); //       Windows line endings as a single character
+                self.read();
+                self.read();
                 return Ok('\n');
             }
             // Strings are correctly terminated by a double quote character. But they may also
@@ -2327,8 +2327,6 @@ mod tests {
         }
     }
 
-    // TODO: combined errors
-
     #[test]
     fn integer_type_suffixes() {
         check! {
@@ -2529,8 +2527,6 @@ mod tests {
         }
     }
 
-    // TODO: combined errors
-
     #[test]
     fn float_type_suffixes() {
         check! {
@@ -2727,16 +2723,6 @@ mod tests {
         }
     }
 
-    // We adopt a simple heuristic for the case of missing closing quotes in character literals.
-    // If we see a quote on the same line then our incorrect multi-character literal spans between
-    // these quotes (it may mean a string with incorrect quotes). If we find no quotes on the line
-    // then maybe the quote character is missing after that single character we saw, or maybe that
-    // first quote is erroneously placed, or maybe there are several incorrect characters here.
-    // As with strings, it's better to not try to guess the meaning of arbitrary invalid sequences.
-    // We do not backtrack so we just eat everything up to the line end as an unrecognized token.
-    //
-    // TODO: shouldn't this be placed near the code that does this? the tests could xref to it.
-
     #[test]
     fn character_multicharacter_literals() {
         check! {
@@ -2835,13 +2821,6 @@ mod tests {
             (1, 3), (6, 9), (12, 17), (22, 24);
         }
     }
-
-    // A similar heuristic is used for missing curly braces.
-    // If character termination quote is seen before a brace, the brace is inserted.
-    // If no character termination quote is found until the line ending, the whole literal
-    // is considered unrecognized token with an error message about missing brace.
-    //
-    // TODO: the same as earlier
 
     #[test]
     fn character_incorrect_unicode_braces() {
@@ -3245,8 +3224,6 @@ mod tests {
         }
     }
 
-    // TODO: more tests
-
     #[test]
     fn string_type_suffixes() {
         check! {
@@ -3426,10 +3403,6 @@ mod tests {
             ( 4,  5), (16, 17), (26, 27), (27, 28), (28, 29);
         }
     }
-
-    // TODO: more tests?
-    //       Like, unrecognized starts of raw strings, "r#####foo"?
-    //       However, maybe these should be parsed as invalid multipart identifiers.
 
     #[test]
     fn raw_string_type_suffixes() {
@@ -4202,8 +4175,6 @@ mod tests {
             ("r#\"awr\"#"       => Literal(RawString, "awr"));
         }
     }
-
-    // TODO: boundary tests between all token types
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Symbols

--- a/src/libsyntax/lexer.rs
+++ b/src/libsyntax/lexer.rs
@@ -43,10 +43,10 @@ pub struct ScannedToken {
 /// However, a scanner will never reconsider its decisions about what it saw and where it was.
 pub trait Scanner {
     /// Checks whether the end of token stream has been reached.
-    /// If it is reached, the scanner will produce only `Token::EOF`.
+    /// If it is reached, the scanner will produce only `Token::Eof`.
     fn at_eof(&self) -> bool;
 
-    /// Extracts and returns the next token from the stream. Returns `Token::EOF`
+    /// Extracts and returns the next token from the stream. Returns `Token::Eof`
     /// if the end of stream has been reached and no more tokens are available.
     fn next_token(&mut self) -> ScannedToken;
 }
@@ -175,7 +175,7 @@ impl<'a> StringScanner<'a> {
     fn next(&mut self) -> ScannedToken {
         if self.at_eof() {
             return ScannedToken {
-                tok: Token::EOF,
+                tok: Token::Eof,
                 span: Span::new(self.pos, self.pos)
             };
         }
@@ -184,7 +184,7 @@ impl<'a> StringScanner<'a> {
         let tok = self.scan_token();
         let end = self.prev_pos;
 
-        assert!(tok != Token::EOF);
+        assert!(tok != Token::Eof);
 
         return ScannedToken {
             tok: tok,
@@ -4535,7 +4535,7 @@ mod tests {
             bytes += s.len();
         }
 
-        all_tok.push(ScannedToken { tok: Token::EOF, span: Span::new(bytes, bytes) });
+        all_tok.push(ScannedToken { tok: Token::Eof, span: Span::new(bytes, bytes) });
 
         return (all_str, all_tok);
     }
@@ -4556,7 +4556,7 @@ mod tests {
 
             tokens.push(token.clone());
 
-            if token.tok == Token::EOF {
+            if token.tok == Token::Eof {
                 break;
             }
         }

--- a/src/libsyntax/tokens.rs
+++ b/src/libsyntax/tokens.rs
@@ -14,7 +14,7 @@ use intern_pool::Atom;
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Token {
     /// Marker token denoting the end-of-token-stream condition.
-    EOF,
+    Eof,
 
     /// Non-significant whitespace.
     Whitespace,


### PR DESCRIPTION
- Remove start/end fields from StringScanner
- Cleanup TODOs
- Rename Token::EOF into snake case

Links: #1
