### PR TITLE
Initial parser

### DIFF
--- a/src/libsyntax/diagnostics.rs
+++ b/src/libsyntax/diagnostics.rs
@@ -49,6 +49,10 @@ pub trait Reporter {
 }
 
 /// Convenience wrapper for easy reporting of diagnostics related to spans of source code.
+///
+/// The diagnostics may be reported either immediately using methods like
+/// [`error()`](#method.error), or they can be constructed incrementally with the help of methods
+/// like [`prepare_error()`](#method.prepare_error).
 pub struct Handler {
     reporter: RefCell<Box<Reporter>>,
 }
@@ -69,5 +73,95 @@ impl Handler {
     /// Reports an error at given span with the given message.
     pub fn error(&self, span: Span, message: &str) {
         self.reporter.borrow_mut().report(Severity::Error, message, Some(span));
+    }
+
+    /// Start building a fatal error at given span with the given message.
+    pub fn prepare_fatal<'a>(&'a self, span: Span, message: &str) -> DiagnosticBuilder<'a> {
+        let mut diagnostic = DiagnosticBuilder::new(&self.reporter, Severity::Fatal, message);
+        diagnostic.span(span);
+        return diagnostic;
+    }
+
+    /// Start building an error at given span with the given message.
+    pub fn prepare_error<'a>(&'a self, span: Span, message: &str) -> DiagnosticBuilder<'a> {
+        let mut diagnostic = DiagnosticBuilder::new(&self.reporter, Severity::Error, message);
+        diagnostic.span(span);
+        return diagnostic;
+    }
+}
+
+/// Delayed diagnostic builder.
+///
+/// Some errors produce diagnostics which may be refined on upper processsing levels. This builder
+/// allows to construct an initial diagnostic and keep this data around while the error bubbles up
+/// to higher levels. Callers may fill in additional data before finally reporting the diagnostic.
+///
+/// Builders cannot be directly instantiated. Use [`Handler`'s](struct.Handler.html) methods like
+/// [`prepare_fatal()`](struct.Handler.html#method.prepare_fatal) to start building a diagnostic.
+/// The diagnostic can then be reported to the handler's `Reporter` with
+/// [`report()`](#method.report).
+///
+/// The builder is marked with `#[must_use]` and will panic if [`report()`](#method.report)
+/// has not been called during its lifetime. This ensures that diagnostics cannot be lost
+/// during processing.
+#[must_use]
+pub struct DiagnosticBuilder<'a> {
+    /// The reporter that will be used to report this diagnostic when it is complete.
+    reporter: &'a RefCell<Box<Reporter>>,
+
+    /// Set to true when the diagnostic has been reported.
+    completed: bool,
+
+    /// Diagnostic severity.
+    severity: Severity,
+
+    /// Diagnostic message.
+    message: String,
+
+    /// Diagnostic location (optional).
+    location: Option<Span>,
+}
+
+impl<'a> DiagnosticBuilder<'a> {
+    /// Make a new diagnostic builder.
+    ///
+    /// This is an internal convenience wrapper for builder construction. Use Handler's methods
+    /// to instantiate properly filled-in diagnostic builders.
+    fn new(reporter: &'a RefCell<Box<Reporter>>, severity: Severity, message: &str)
+        -> DiagnosticBuilder<'a>
+    {
+        DiagnosticBuilder {
+            reporter: reporter,
+            completed: false,
+            severity: severity,
+            message: message.to_owned(),
+            location: None,
+        }
+    }
+
+    /// Report the complete diagnostic.
+    ///
+    /// Each diagnostic is reported only once.
+    pub fn report(&mut self) {
+        if self.completed {
+            return;
+        }
+        self.reporter.borrow_mut().report(self.severity, &self.message, self.location);
+        self.completed = true;
+    }
+
+    /// Set the span of the diagnostic.
+    pub fn span(&mut self, span: Span) -> &mut Self {
+        self.location = Some(span);
+        self
+    }
+}
+
+/// Panic if the constructed diagnostic has not been reported yet.
+impl<'a> Drop for DiagnosticBuilder<'a> {
+    fn drop(&mut self) {
+        if !self.completed {
+            panic!("dropped incomplete diagnostic")
+        }
     }
 }

--- a/src/libsyntax/diagnostics.rs
+++ b/src/libsyntax/diagnostics.rs
@@ -11,7 +11,7 @@
 
 use std::cell::RefCell;
 
-/// Span of a token.
+/// Span of a token or an expression.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Span {
     /// Byte offset of the first character of the span.
@@ -48,15 +48,15 @@ pub trait Reporter {
     fn report(&mut self, severity: Severity, message: &str, loc: Option<Span>);
 }
 
-/// Convenience reporter for easy reporting of diagnostics related to spans of source code.
-pub struct SpanReporter {
+/// Convenience wrapper for easy reporting of diagnostics related to spans of source code.
+pub struct Handler {
     reporter: RefCell<Box<Reporter>>,
 }
 
-impl SpanReporter {
-    /// Constructs a new SpanReporter for a given reporter.
-    pub fn with_reporter(reporter: Box<Reporter>) -> SpanReporter {
-        SpanReporter {
+impl Handler {
+    /// Constructs a new Handler for a given reporter.
+    pub fn with_reporter(reporter: Box<Reporter>) -> Handler {
+        Handler {
             reporter: RefCell::new(reporter)
         }
     }

--- a/src/libsyntax/expressions.rs
+++ b/src/libsyntax/expressions.rs
@@ -1,0 +1,47 @@
+// Copyright (c) 2016, ilammy
+//
+// Licensed under MIT license (see LICENSE file in the root directory).
+// This file may be copied, distributed, and modified only in accordance
+// with the terms specified by this license.
+
+//! Sash expression definitions.
+//!
+//! This module contains definitions of various expressions recognized and processed by Sash
+//! parser.
+
+use diagnostics::{Span};
+use intern_pool::{Atom};
+
+/// An expression recognized by the parser.
+#[derive(PartialEq, Eq)]
+pub struct Expression {
+    /// The kind of the expression.
+    pub kind: ExpressionKind,
+
+    /// The span of the expression.
+    pub span: Span,
+}
+
+/// Types of expressions recognized by the parser.
+#[derive(PartialEq, Eq)]
+pub enum ExpressionKind {
+    /// A top-level implicit module.
+    ImplicitModule {
+        body: Vec<Expression>,
+    },
+
+    /// A top-level library definition.
+    Library {
+        name: Atom,
+        body: Vec<Expression>,
+    },
+
+    /// A nested explicit module.
+    Module {
+        name: Atom,
+        body: Vec<Expression>,
+    },
+
+    /// An unrecognized sequence of tokens.
+    Unrecognized,
+}

--- a/src/libsyntax/lexer.rs
+++ b/src/libsyntax/lexer.rs
@@ -12,7 +12,7 @@
 use std::char;
 
 use tokens::{Token, Delimiter, Keyword, Lit};
-use diagnostics::{Span, SpanReporter};
+use diagnostics::{Span, Handler};
 use intern_pool::{Atom, InternPool};
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -89,7 +89,7 @@ pub struct StringScanner<'a> {
     //
 
     /// Our designated responsible for diagnostic processing.
-    report: &'a SpanReporter,
+    report: &'a Handler,
 }
 
 impl<'a> Scanner for StringScanner<'a> {
@@ -104,14 +104,14 @@ impl<'a> Scanner for StringScanner<'a> {
 
 impl<'a> StringScanner<'a> {
     /// Makes a new scanner for the given string which will report scanning errors
-    /// to the given reporter and intern strings into the given pool.
-    pub fn new(s: &'a str, pool: &'a InternPool, reporter: &'a SpanReporter) -> StringScanner<'a> {
+    /// to the given handler and intern strings into the given pool.
+    pub fn new(s: &'a str, pool: &'a InternPool, handler: &'a Handler) -> StringScanner<'a> {
         let mut scanner = StringScanner {
             buf: s,
             pool: pool,
             atoms: AtomCache::new(pool),
             cur: None, pos: 0, prev_pos: 0,
-            report: reporter,
+            report: handler,
         };
         scanner.read();
         scanner

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -9,10 +9,13 @@
 //! This crate contains modules implementing the most front end of Sash front-end:
 //!
 //!   - lexical analysis
+//!   - syntax analysis
 
 extern crate unicode;
 
 pub mod diagnostics;
+pub mod expressions;
 pub mod intern_pool;
 pub mod lexer;
+pub mod parser;
 pub mod tokens;

--- a/src/libsyntax/parser.rs
+++ b/src/libsyntax/parser.rs
@@ -1,0 +1,644 @@
+// Copyright (c) 2016, ilammy
+//
+// Licensed under MIT license (see LICENSE file in the root directory).
+// This file may be copied, distributed, and modified only in accordance
+// with the terms specified by this license.
+
+//! Sash syntax analyzer.
+//!
+//! This module contains definition and implementation of the _syntax analyzer_ which converts
+//! a stream of tokens into an expression tree.
+
+use std::iter::Iterator;
+
+use diagnostics::{DiagnosticBuilder, Handler, Span};
+use expressions::{Expression, ExpressionKind};
+use intern_pool::{InternPool};
+use lexer::{Scanner, ScannedToken};
+use tokens::{Token, Delimiter, Keyword};
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// The parser
+//
+
+/// Sash parser.
+///
+/// A parser analyzes a stream of tokens to find grammatically valid patterns in it and produce
+/// a parse tree of expressions denoted by the token stream.
+pub struct Parser<'a, Tokens> {
+    /// The token stream to parse.
+    tokens: Tokens,
+
+    /// Set to true when we have consumed everything in the stream.
+    eof_reached: bool,
+
+    /// The intern pool for atoms stored in scanned tokens.
+    pool: &'a InternPool,
+
+    // Parsing state
+    //
+    //     buf:
+    //     +---+-----------------+--------------+
+    //     | } | Keyword(Module) | Ident("foo") |
+    //     +---+-----------------+--------------+
+    //       ^   ^                 ^
+    //       |   |                next(): lookahead token used by the parser to decide
+    //       |   |                        what to expect next
+    //       |   |
+    //       |  cur(): the token that the parser is currently looking at
+    //       |
+    //      prev(): lookbehind token used by the parser mostly for error reporting
+    //
+    //     tokens:
+    //     +---+-------------------+--------------+----
+    //     | { | Keyword(Function) | Ident("bar") | ...
+    //     +---+-------------------+--------------+----
+    //     remaining token stream (after the lookahead)
+
+    /// Token buffer.
+    buf: [ScannedToken; 3],
+
+    //
+    // Diagnostic reporting
+    //
+
+    /// Our designated responsible for diagnostic processing.
+    handler: &'a Handler,
+}
+
+type ParseResult<'a> = Result<Expression, DiagnosticBuilder<'a>>;
+
+impl<'a, S> Parser<'a, S>
+    where S: Scanner
+{
+    /// Create a new parser for the given token stream.
+    ///
+    /// The pool is expected to be the same as the one used by the scanner (i.e., the atoms found
+    /// in tokens must be there or we will panic). Any syntax errors will be reported using the
+    /// provided error handler.
+    pub fn new(tokens: S, pool: &'a InternPool, handler: &'a Handler) -> Parser<'a, S> {
+        let placeholder = ScannedToken {
+            tok: Token::Eof,
+            span: Span::new(0, 0),
+        };
+        let mut parser = Parser {
+            tokens: tokens,
+            eof_reached: false,
+            pool: pool,
+            buf: [
+                placeholder.clone(),
+                placeholder.clone(),
+                placeholder.clone(),
+            ],
+            handler: handler,
+        };
+        parser.fill_buffer();
+        return parser;
+    }
+
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Stream control
+
+    /// Peek at the previous token that has been processed.
+    fn prev(&self) -> &ScannedToken {
+        &self.buf[0]
+    }
+
+    /// Peek at the current token being processed.
+    fn cur(&self) -> &ScannedToken {
+        &self.buf[1]
+    }
+
+    /// Peek at the next token to be processed.
+    fn next(&self) -> &ScannedToken {
+        &self.buf[2]
+    }
+
+    /// Check whether the end of token stream has been reached.
+    fn at_eof(&self) -> bool {
+        self.cur().tok == Token::Eof
+    }
+
+    /// Initialize the token buffer.
+    fn fill_buffer(&mut self) {
+        // Read in the to-be-current token and the lookahead.
+        self.read();
+        self.read();
+    }
+
+    /// Bump the buffer, reading in the next token.
+    fn read(&mut self) {
+        self.buf.swap(0, 1);
+        self.buf.swap(1, 2);
+        self.buf[2] = self.next_token();
+    }
+
+    /// Fetch the next significant (non-whitespace) token.
+    fn next_token(&mut self) -> ScannedToken {
+        loop {
+            let t = self.tokens.next_token();
+
+            match t.tok {
+                Token::Comment | Token::Whitespace => {
+                    continue;
+                }
+                _ => {
+                    return t;
+                }
+            }
+        }
+    }
+
+    /// Clear the token buffer and mark the stream as exhausted.
+    fn drain(&mut self) {
+        let placeholder = ScannedToken {
+            tok: Token::Eof,
+            span: Span::new(0, 0),
+        };
+        self.buf[0] = placeholder.clone();
+        self.buf[1] = placeholder.clone();
+        self.buf[2] = placeholder.clone();
+
+        self.eof_reached = true;
+    }
+
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Parser entry points
+
+    /// Parse the entire token stream containing one source file.
+    ///
+    /// Returns None if no output can be produced, either due to the token stream being empty,
+    /// or due to unrecoverable parsing errors.
+    pub fn parse_all(&mut self) -> Option<Expression> {
+        // Return None if we have already consumed all tokens.
+        if self.eof_reached {
+            return None;
+        }
+
+        // Collect top-level expressions into an implicit module.
+        let mut body = Vec::new();
+
+        while !self.at_eof() {
+            match self.parse_toplevel() {
+                Ok(expr) => {
+                    body.push(expr);
+                }
+                Err(mut error) => {
+                    // Only fatal issues bubble up to here, so report this and get out.
+                    error.report();
+
+                    // Don't forget to drain the token stream before we leave, it's poisoned.
+                    self.drain();
+
+                    return None;
+                }
+            }
+        }
+        self.eof_reached = true;
+
+        // If the source file is empty then return the span of Token::Eof.
+        // It's not that the user should care.
+        let span = if body.is_empty() {
+            self.cur().span
+        } else {
+            let first_span = body.first().unwrap().span;
+            let last_span = body.last().unwrap().span;
+            Span::new(first_span.from, last_span.to)
+        };
+
+        // Wrap the top-level expressions into an implicit module.
+        return Some(Expression {
+            kind: ExpressionKind::ImplicitModule {
+                body: body,
+            },
+            span: span
+        });
+    }
+
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Top level constructs
+
+    /// Parse a single top-level definition.
+    fn parse_toplevel(&mut self) -> ParseResult<'a> {
+        match self.cur().tok {
+            Token::Keyword(Keyword::Module) => {
+                self.parse_module()
+            }
+            Token::Keyword(Keyword::Library) => {
+                self.parse_library()
+            }
+            // Skip any invalid expressions after guessing their form (block or statement).
+            _ => {
+                self.parse_unrecognized_block_or_statement()
+            }
+        }
+    }
+
+    /// Parse an invalid expression of unknown form and return Unrecognized. If the expression has
+    /// an opening brace then it is treated as a block expression and will be scanned until the
+    /// matching closing brace. If we see a semicolon then it must have been a statement and we
+    /// stop at that point. Everything else is simply skipped over, though we still check that
+    /// all delimiters are properly nested.
+    fn parse_unrecognized_block_or_statement(&mut self) -> ParseResult<'a> {
+        let unrecognized_start = self.cur().span.from;
+
+        loop {
+            match self.cur().tok {
+                Token::Eof => {
+                    let unrecognized_end = self.cur().span.to;
+
+                    return Ok(Expression {
+                        kind: ExpressionKind::Unrecognized,
+                        span: Span::new(unrecognized_start, unrecognized_end),
+                    });
+                }
+                Token::Semicolon => {
+                    let unrecognized_end = self.cur().span.to;
+
+                    self.read();
+
+                    return Ok(Expression {
+                        kind: ExpressionKind::Unrecognized,
+                        span: Span::new(unrecognized_start, unrecognized_end),
+                    });
+                }
+                Token::OpenDelim(delim) => {
+                    let e = try!(self.skip_delimited_expression(delim));
+                    let unrecognized_end = e.span.to;
+
+                    if delim == Delimiter::Brace {
+                        return Ok(Expression {
+                            kind: ExpressionKind::Unrecognized,
+                            span: Span::new(unrecognized_start, unrecognized_end),
+                        });
+                    }
+                }
+                Token::CloseDelim(_) => {
+                    return Err(self.handler.prepare_fatal(self.cur().span,
+                        "unmatched closing delimiter"));
+                }
+                _ => {
+                    self.read();
+                }
+            }
+        }
+    }
+
+    /// Skip over a subexpression delimited by `delim`. This method does not parse the expression,
+    /// but it does check for unmatched delimiters: an Err is returned in this case. Otherwise it
+    /// returns an Ok(Unrecognized) result.
+    fn skip_delimited_expression(&mut self, delim: Delimiter) -> ParseResult<'a> {
+        let expr_from = self.cur().span.from;
+
+        // We do expect this to start with proper delimiter.
+        assert!(self.cur().tok == Token::OpenDelim(delim));
+        self.read();
+
+        loop {
+            match self.cur().tok {
+                // If we see another opener then recurse into the subexpression. This method
+                // returns only fatal errors, so bubble them up if they are encountered.
+                Token::OpenDelim(open_delim) => {
+                    try!(self.skip_delimited_expression(open_delim));
+                }
+                Token::CloseDelim(close_delim) => {
+                    // If this is the delimiter we are looking for then we are done,
+                    // return some dummy node.
+                    if close_delim == delim {
+                        let expr_to = self.cur().span.to;
+
+                        self.read();
+
+                        return Ok(Expression {
+                            kind: ExpressionKind::Unrecognized,
+                            span: Span::new(expr_from, expr_to),
+                        });
+                    } else {
+                        // Otherwise, this is a fatal failure. Technically, we could skip this
+                        // and try to continue reading, but unmatched closing delimiter may mean
+                        // that _the opening one_ was incorrect and we may have erroneously skipped
+                        // over the half of the source code. Don't take chances and let the human
+                        // make a decision on how to fix this.
+                        return Err(self.handler.prepare_fatal(self.cur().span,
+                            format!("invalid closing delimiter, expected {:?}",
+                                delim).as_ref()));
+                    }
+                }
+                Token::Eof => {
+                    // TODO: tell the user where matching opener is
+                    return Err(self.handler.prepare_fatal(self.cur().span,
+                        format!("missing closing delimiter, expected {:?}", delim).as_ref()));
+                }
+                _ => {
+                    self.read();
+                }
+            }
+        }
+    }
+
+    /// Parse a single module definition.
+    fn parse_module(&mut self) -> ParseResult<'a> {
+        // A module starts with a 'module' keyword which we have already seen.
+        assert!(self.cur().tok == Token::Keyword(Keyword::Module));
+        self.read();
+
+        let module_start = self.prev().span.from;
+        let name_start = self.cur().span.from;
+
+        // Then we expect an identifier with the name of the module.
+        let module_name = match self.cur().tok {
+            // We're lucky if this is so. Read over it and go on.
+            Token::Identifier(module_name) => {
+                self.read();
+                Some(module_name)
+            }
+            // Otherwise mark it as missing and go on.
+            _ => {
+                None
+            }
+        };
+
+        // After a name we expect to see an opening brace.
+        let atomic_name = match self.cur().tok {
+            // Got it!
+            Token::OpenDelim(Delimiter::Brace) => {
+                self.read();
+                true
+            }
+            // Otherwise, let's see what we can do... Apparently, the user does not know the
+            // module syntax, so we start dropping tokens until we see something sensible.
+            _ => {
+                loop {
+                    match self.cur().tok {
+                        // Okay, this seems like a start of the module body so go out.
+                        Token::OpenDelim(Delimiter::Brace) => {
+                            self.read();
+                            break;
+                        }
+                        // Top-level keywords are unexpected before module definition starts so
+                        // assume that the 'module' keyword we've seen is a lie. Discard everything
+                        // up to this point in hope that the parser will resynchronize. Closing
+                        // brace may mean the end of some enclosing block (or it is unmatched and
+                        // will result in a fatal error anyway).
+                        Token::Keyword(Keyword::Module) | Token::Keyword(Keyword::Library) |
+                        Token::CloseDelim(Delimiter::Brace) => {
+                            let module_end = self.prev().span.to;
+
+                            self.handler.error(Span::new(module_start, module_end),
+                                "invalid module definition");
+
+                            return Ok(Expression {
+                                kind: ExpressionKind::Unrecognized,
+                                span: Span::new(module_start, module_end),
+                            });
+                        }
+                        // Semicolon is a definite terminator of a non-block item. The user seems
+                        // to believe that a module is one while it's not. Eat the semicolon and
+                        // return a dummy node. The parser should resynchronize after this.
+                        Token::Semicolon => {
+                            let module_end = self.cur().span.to;
+
+                            self.handler.error(Span::new(module_start, module_end),
+                                "invalid module definition");
+
+                            self.read();
+
+                            return Ok(Expression {
+                                kind: ExpressionKind::Unrecognized,
+                                span: Span::new(module_start, module_end),
+                            });
+                        }
+                        // Delimiters other than the opening brace are totally not expected here,
+                        // so we cannot assume any sane local mistake made by the user. Just skip
+                        // over it, only check for unmatched delimiters, and go on if possible.
+                        Token::OpenDelim(delim) => {
+                            try!(self.skip_delimited_expression(delim));
+                        }
+                        Token::CloseDelim(_) => {
+                            return Err(self.handler.prepare_fatal(self.cur().span,
+                                "unmatched closing delimiter"));
+                        }
+                        // If there is nothing more in the stream then we can't recover.
+                        Token::Eof => {
+                            return Err(self.handler.prepare_fatal(self.cur().span,
+                                "expected a module definition"));
+                        }
+                        // Skip everything else.
+                        _ => {
+                            self.read();
+                        }
+                    }
+                }
+                false
+            }
+        };
+
+        let name_end = self.prev().span.to;
+
+        // O-o-okay, now we're scanning the module body until we see a matching closing brace.
+        let mut module_body = Vec::new();
+
+        loop {
+            match self.cur().tok {
+                // We're done. Eat the brace and go out.
+                Token::CloseDelim(Delimiter::Brace) => {
+                    self.read();
+                    break;
+                }
+                // Woops, the brace has just lost its twin sister :(
+                Token::Eof => {
+                    // TODO: tell the user which module we expect this for
+                    return Err(self.handler.prepare_fatal(self.cur().span,
+                        "missing closing brace '}'"));
+                }
+                // Otherwise, this must be some top-level definition. If it has been parsed okay
+                // then store it. If the parser has failed to recover then we can't proceeed and
+                // just report the error to the caller.
+                _ => {
+                    match self.parse_toplevel() {
+                        Ok(expr) => {
+                            module_body.push(expr);
+                        }
+                        Err(error) => {
+                            return Err(error);
+                        }
+                    }
+                }
+            }
+        }
+
+        let module_end = self.prev().span.to;
+
+        let module_name = if atomic_name && module_name.is_some() {
+            module_name.unwrap()
+        } else {
+            // If we have invalid module name then complain about it and use some stub instead.
+            self.handler.error(Span::new(name_start, name_end),
+                "invalid module name");
+
+            self.pool.intern("<invalid-name>")
+        };
+
+        // We have seen everything that has to be seen. Return the module.
+        return Ok(Expression {
+            kind: ExpressionKind::Module {
+                name: module_name,
+                body: module_body,
+            },
+            span: Span::new(module_start, module_end),
+        });
+    }
+
+    /// Parse a single library definition.
+    fn parse_library(&mut self) -> ParseResult<'a> {
+        // A library starts with a 'library' keyword which we have already seen.
+        assert!(self.cur().tok == Token::Keyword(Keyword::Library));
+        self.read();
+
+        let library_start = self.prev().span.from;
+        let name_start = self.cur().span.from;
+
+        // Then we expect an identifier with the name of the library.
+        let library_name = match self.cur().tok {
+            // We're lucky if this is so. Read over it and go on.
+            Token::Identifier(library_name) => {
+                self.read();
+                Some(library_name)
+            }
+            // Otherwise mark it as missing and go on.
+            _ => {
+                None
+            }
+        };
+
+        // After a name we expect to see an opening brace.
+        let atomic_name = match self.cur().tok {
+            // Got it!
+            Token::OpenDelim(Delimiter::Brace) => {
+                self.read();
+                true
+            }
+            // Otherwise, let's see what we can do... Apparently, the user does not know the
+            // library syntax, so we start dropping tokens until we see something sensible.
+            _ => {
+                loop {
+                    match self.cur().tok {
+                        // Okay, this seems like a start of the library body so go out.
+                        Token::OpenDelim(Delimiter::Brace) => {
+                            self.read();
+                            break;
+                        }
+                        // Top-level keywords are unexpected before library definition starts so
+                        // assume that the 'library' keyword we've seen is a lie. Discard all stuff
+                        // up to this point in hope that the parser will resynchronize. Closing
+                        // brace may mean the end of some enclosing block (or it is unmatched and
+                        // will result in a fatal error anyway).
+                        Token::Keyword(Keyword::Module) | Token::Keyword(Keyword::Library) |
+                        Token::CloseDelim(Delimiter::Brace) => {
+                            let library_end = self.prev().span.to;
+
+                            self.handler.error(Span::new(library_start, library_end),
+                                "invalid library definition");
+
+                            return Ok(Expression {
+                                kind: ExpressionKind::Unrecognized,
+                                span: Span::new(library_start, library_end),
+                            });
+                        }
+                        // Semicolon is a definite terminator of a non-block item. The user seems
+                        // to believe that a library is one while it's not. Eat the semicolon and
+                        // return a dummy node. The parser should resynchronize after this.
+                        Token::Semicolon => {
+                            let library_end = self.cur().span.to;
+
+                            self.handler.error(Span::new(library_start, library_end),
+                                "invalid library definition");
+
+                            self.read();
+
+                            return Ok(Expression {
+                                kind: ExpressionKind::Unrecognized,
+                                span: Span::new(library_start, library_end),
+                            });
+                        }
+                        // Delimiters other than the opening brace are totally not expected here,
+                        // so we cannot assume any sane local mistake made by the user. Just skip
+                        // over it, only check for unmatched delimiters, and go on if possible.
+                        Token::OpenDelim(delim) => {
+                            try!(self.skip_delimited_expression(delim));
+                        }
+                        Token::CloseDelim(_) => {
+                            return Err(self.handler.prepare_fatal(self.cur().span,
+                                "unmatched closing delimiter"));
+                        }
+                        // If there is nothing more in the stream then we can't recover.
+                        Token::Eof => {
+                            return Err(self.handler.prepare_fatal(self.cur().span,
+                                "expected a library definition"));
+                        }
+                        // Skip everything else.
+                        _ => {
+                            self.read();
+                        }
+                    }
+                }
+                false
+            }
+        };
+
+        let name_end = self.prev().span.to;
+
+        // O-o-okay, now we're scanning the library body until we see a matching closing brace.
+        let mut library_body = Vec::new();
+
+        loop {
+            match self.cur().tok {
+                // We're done. Eat the brace and go out.
+                Token::CloseDelim(Delimiter::Brace) => {
+                    self.read();
+                    break;
+                }
+                // Woops, the brace has just lost its twin sister :(
+                Token::Eof => {
+                    // TODO: tell the user which library we expect this for
+                    return Err(self.handler.prepare_fatal(self.cur().span,
+                        "missing closing brace '}'"));
+                }
+                // Otherwise, this must be some top-level definition. If it has been parsed okay
+                // then store it. If the parser has failed to recover then we can't proceeed and
+                // just report the error to the caller.
+                _ => {
+                    match self.parse_toplevel() {
+                        Ok(expr) => {
+                            library_body.push(expr);
+                        }
+                        Err(error) => {
+                            return Err(error);
+                        }
+                    }
+                }
+            }
+        }
+
+        let library_end = self.prev().span.to;
+
+        let library_name = if atomic_name && library_name.is_some() {
+            library_name.unwrap()
+        } else {
+            // If we have invalid library name then complain about it and use some stub instead.
+            self.handler.error(Span::new(name_start, name_end),
+                "invalid library name");
+
+            self.pool.intern("<invalid-name>")
+        };
+
+        // We have seen everything that has to be seen. Return the library.
+        return Ok(Expression {
+            kind: ExpressionKind::Library {
+                name: library_name,
+                body: library_body,
+            },
+            span: Span::new(library_start, library_end),
+        });
+    }
+}

--- a/src/libsyntax/tests/lexer.rs
+++ b/src/libsyntax/tests/lexer.rs
@@ -12,7 +12,7 @@ extern crate syntax;
 
 use syntax::lexer::{ScannedToken, StringScanner, Scanner};
 use syntax::tokens::{Token, Delimiter, Keyword, Lit};
-use syntax::diagnostics::{Span, SpanReporter, Severity};
+use syntax::diagnostics::{Span, Handler, Severity};
 use syntax::intern_pool::{Atom, InternPool};
 
 mod utils;
@@ -3111,7 +3111,7 @@ fn process_test_string(whole_string: &str, pool: &InternPool) -> ScannerTestResu
     let mut tokens = Vec::new();
     let diagnostics = Rc::new(RefCell::new(Vec::new()));
     let reporter = SinkReporter::new(diagnostics.clone());
-    let handler = SpanReporter::with_reporter(Box::new(reporter));
+    let handler = Handler::with_reporter(Box::new(reporter));
 
     let mut scanner = StringScanner::new(whole_string, pool, &handler);
 

--- a/src/libsyntax/tests/parser.rs
+++ b/src/libsyntax/tests/parser.rs
@@ -1,0 +1,593 @@
+// Copyright (c) 2016, ilammy
+//
+// Licensed under MIT license (see LICENSE file in the root directory).
+// This file may be copied, distributed, and modified only in accordance
+// with the terms specified by this license.
+
+//! Parser test suite.
+//!
+//! This verifies all expressions parseable by Sash parser.
+
+extern crate syntax;
+
+use syntax::parser::{Parser};
+use syntax::diagnostics::{Handler};
+use syntax::expressions::{Expression};
+use syntax::intern_pool::{InternPool};
+use syntax::lexer::{StringScanner};
+
+mod utils {
+    pub mod expression_builders;
+    pub mod expression_diff;
+    pub mod stubs;
+}
+
+use utils::expression_builders::{ImplicitModule, Library, Module, Unrecognized};
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Smoke test of test harness
+
+#[test]
+fn empty_stream() {
+    verify_parser_output("", ImplicitModule::new());
+}
+
+#[test]
+fn empty_stream_whitespace_and_comments() {
+    verify_parser_output("
+// test test test
+
+/* another test */",
+    ImplicitModule::new());
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Unrecognized expressions
+
+#[test]
+fn unrecognized_block_skip_simple() {
+    verify_parser_output("
+module first {}
+
+wagon { foo bar }
+
+module second {}
+",
+    ImplicitModule::new()
+        .push(Module::new("first"))
+        .push(Unrecognized::new())
+        .push(Module::new("second")));
+}
+
+#[test]
+fn unrecognized_block_skip_with_parens() {
+    verify_parser_output("
+module first {}
+
+beaver (foo bar) { zog; }
+
+module second {}
+",
+    ImplicitModule::new()
+        .push(Module::new("first"))
+        .push(Unrecognized::new())
+        .push(Module::new("second")));
+}
+
+#[test]
+fn unrecognized_block_cant_recover_unmatched() {
+    verify_parser_failure("
+module first {}
+
+giraffe[X] { unbalanced :) }
+
+module second {}");
+}
+
+#[test]
+fn unrecognized_statement_skip_simple_1() {
+    verify_parser_output("
+module first {}
+
+exterminate [all] \"humans\";
+
+module second {}
+",
+    ImplicitModule::new()
+        .push(Module::new("first"))
+        .push(Unrecognized::new())
+        .push(Module::new("second")));
+}
+
+#[test]
+fn unrecognized_statement_skip_simple_2() {
+    verify_parser_output("
+module first {}
+
+this = was(a, triumph);
+
+module second {}
+",
+    ImplicitModule::new()
+        .push(Module::new("first"))
+        .push(Unrecognized::new())
+        .push(Module::new("second")));
+}
+
+#[test]
+fn unrecognized_statement_skip_after_block() {
+    verify_parser_output("
+module first {}
+
+x{};
+
+module second {}
+",
+    ImplicitModule::new()
+        .push(Module::new("first"))
+        .push(Unrecognized::new())
+        .push(Unrecognized::new())
+        .push(Module::new("second")));
+}
+
+#[test]
+fn unrecognized_statement_cant_recover_unmatched_1() {
+    verify_parser_failure("
+module first {}
+
+bork}
+
+module second {}");
+}
+
+#[test]
+fn unrecognized_statement_cant_recover_unmatched_2() {
+    verify_parser_failure("
+module first {}
+
+bork]
+
+module second {}");
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Modules
+
+#[test]
+fn modules_basic() {
+    verify_parser_output("
+// Simple module
+module example1
+{
+}
+
+// Nested modules
+module example2
+{
+    module nested
+    {
+    }
+}
+
+// Unicode-named modules
+module \u{043F}\u{0440}\u{0438}\u{043C}\u{0435}\u{0440}
+{
+}",
+    ImplicitModule::new()
+        .push(Module::new("example1"))
+        .push(Module::new("example2")
+            .push(Module::new("nested")))
+        .push(Module::new("\u{043F}\u{0440}\u{0438}\u{043C}\u{0435}\u{0440}")));
+}
+
+#[test]
+fn modules_recover_invalid_names() {
+    verify_parser_output("
+// Missing name
+module {}
+
+// Invalid name
+module \"foo\" {}
+
+// Seriously invalid name
+module (2 + 2) * foo[bar] {}
+
+// Nesting
+module 1::2::3
+{
+    module A
+    {
+        module ### {}
+        module B B
+        {
+            module '\u{4567}'{}
+        }
+        module .{}
+    }
+}",
+    ImplicitModule::new()
+        .push(Module::new("<invalid-name>"))
+        .push(Module::new("<invalid-name>"))
+        .push(Module::new("<invalid-name>"))
+        .push(Module::new("<invalid-name>")
+            .push(Module::new("A")
+                .push(Module::new("<invalid-name>"))
+                .push(Module::new("<invalid-name>")
+                    .push(Module::new("<invalid-name>")))
+                .push(Module::new("<invalid-name>")))));
+}
+
+#[test]
+fn modules_recover_non_block() {
+    verify_parser_output("
+// Missing name
+module;
+
+// Invalid name
+module \"foo\";
+
+// Seriously invalid name
+module !@#$%^&*
+
+// Nesting
+module foo
+{
+    module bar;
+
+    module baz + zog
+    {
+        module module module
+    }
+}",
+    ImplicitModule::new()
+        .push(Unrecognized::new())
+        .push(Unrecognized::new())
+        .push(Unrecognized::new())
+        .push(Module::new("foo")
+            .push(Unrecognized::new())
+            .push(Module::new("<invalid-name>")
+                .push(Unrecognized::new())
+                .push(Unrecognized::new())
+                .push(Unrecognized::new()))));
+}
+
+#[test]
+fn modules_recover_delimited_expressions() {
+    verify_parser_output("
+// Parentheses
+module () {}
+module (something) {}
+module (something(other), else) {}
+
+// Brackets
+module[] {}
+module[u32] {}
+module[Foo[bar]] {}
+
+// Mixed
+module[(;)(:)[(\\/)_..!._(\\/)][]]
+{
+    module(module(module{}))
+    {
+        module
+        [
+            module
+        ]
+    }
+}
+",
+    ImplicitModule::new()
+        .push(Module::new("<invalid-name>"))
+        .push(Module::new("<invalid-name>"))
+        .push(Module::new("<invalid-name>"))
+        .push(Module::new("<invalid-name>"))
+        .push(Module::new("<invalid-name>"))
+        .push(Module::new("<invalid-name>"))
+        .push(Module::new("<invalid-name>")
+            .push(Module::new("<invalid-name>")
+                .push(Unrecognized::new()))));
+}
+
+#[test]
+fn modules_cant_recover_eof_keyword() {
+    verify_parser_failure("
+module
+");
+}
+
+#[test]
+fn modules_cant_recover_eof_name() {
+    verify_parser_failure("
+module foo
+");
+}
+
+#[test]
+fn modules_cant_recover_eof_name_2() {
+    verify_parser_failure("
+module foo bar baz
+");
+}
+
+#[test]
+fn modules_cant_recover_eof_missing_brace() {
+    verify_parser_failure("
+module A {
+");
+}
+
+#[test]
+fn modules_cant_recover_eof_missing_brace_2() {
+    verify_parser_failure("
+module {
+    module
+");
+}
+
+#[test]
+fn modules_cant_recover_unmatched_delimiter_1() {
+    verify_parser_failure("
+module :)
+");
+}
+
+#[test]
+fn modules_cant_recover_unmatched_delimiter_2() {
+    verify_parser_failure("
+module [test[)]
+");
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Libraries
+
+#[test]
+fn libraries_basic() {
+    verify_parser_output("
+// Simple library
+library example1
+{
+}
+
+// Nested modules
+library example2
+{
+    library nested
+    {
+    }
+}
+
+// Unicode-named modules
+library \u{043F}\u{0440}\u{0438}\u{043C}\u{0435}\u{0440}
+{
+}",
+    ImplicitModule::new()
+        .push(Library::new("example1"))
+        .push(Library::new("example2")
+            .push(Library::new("nested")))
+        .push(Library::new("\u{043F}\u{0440}\u{0438}\u{043C}\u{0435}\u{0440}")));
+}
+
+#[test]
+fn libraries_recover_invalid_names() {
+    verify_parser_output("
+// Missing name
+library {}
+
+// Invalid name
+library \"foo\" {}
+
+// Seriously invalid name
+library (2 + 2) * foo[bar] {}
+
+// Nesting
+library 1::2::3
+{
+    library A
+    {
+        library ### {}
+        library B B
+        {
+            library '\u{4567}'{}
+        }
+        library .{}
+    }
+}",
+    ImplicitModule::new()
+        .push(Library::new("<invalid-name>"))
+        .push(Library::new("<invalid-name>"))
+        .push(Library::new("<invalid-name>"))
+        .push(Library::new("<invalid-name>")
+            .push(Library::new("A")
+                .push(Library::new("<invalid-name>"))
+                .push(Library::new("<invalid-name>")
+                    .push(Library::new("<invalid-name>")))
+                .push(Library::new("<invalid-name>")))));
+}
+
+#[test]
+fn libraries_recover_non_block() {
+    verify_parser_output("
+// Missing name
+library;
+
+// Invalid name
+library \"foo\";
+
+// Seriously invalid name
+library !@#$%^&*
+
+// Nesting
+library foo
+{
+    library bar;
+
+    library baz + zog
+    {
+        library library library
+    }
+}",
+    ImplicitModule::new()
+        .push(Unrecognized::new())
+        .push(Unrecognized::new())
+        .push(Unrecognized::new())
+        .push(Library::new("foo")
+            .push(Unrecognized::new())
+            .push(Library::new("<invalid-name>")
+                .push(Unrecognized::new())
+                .push(Unrecognized::new())
+                .push(Unrecognized::new()))));
+}
+
+#[test]
+fn libraries_recover_delimited_expressions() {
+    verify_parser_output("
+// Parentheses
+library () {}
+library (something) {}
+library (something(other), else) {}
+
+// Brackets
+library[] {}
+library[u32] {}
+library[Foo[bar]] {}
+
+// Mixed
+library[(;)(:)[(\\/)_..!._(\\/)][]]
+{
+    library(library(library{}))
+    {
+        library
+        [
+            library
+        ]
+    }
+}
+",
+    ImplicitModule::new()
+        .push(Library::new("<invalid-name>"))
+        .push(Library::new("<invalid-name>"))
+        .push(Library::new("<invalid-name>"))
+        .push(Library::new("<invalid-name>"))
+        .push(Library::new("<invalid-name>"))
+        .push(Library::new("<invalid-name>"))
+        .push(Library::new("<invalid-name>")
+            .push(Library::new("<invalid-name>")
+                .push(Unrecognized::new()))));
+}
+
+#[test]
+fn libraries_cant_recover_eof_keyword() {
+    verify_parser_failure("
+library
+");
+}
+
+#[test]
+fn libraries_cant_recover_eof_name() {
+    verify_parser_failure("
+library foo
+");
+}
+
+#[test]
+fn libraries_cant_recover_eof_name_2() {
+    verify_parser_failure("
+library foo bar baz
+");
+}
+
+#[test]
+fn libraries_cant_recover_eof_missing_brace() {
+    verify_parser_failure("
+library A {
+");
+}
+
+#[test]
+fn libraries_cant_recover_eof_missing_brace_2() {
+    verify_parser_failure("
+library {
+    library
+");
+}
+
+#[test]
+fn libraries_cant_recover_unmatched_delimiter_1() {
+    verify_parser_failure("
+library :)
+");
+}
+
+#[test]
+fn libraries_cant_recover_unmatched_delimiter_2() {
+    verify_parser_failure("
+library [test[)]
+");
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Test helpers
+
+use std::rc::Rc;
+use std::cell::RefCell;
+
+use utils::expression_builders::{Build};
+use utils::expression_diff::{self, ComparisonResult};
+use utils::stubs::{SinkReporter};
+
+/// Verify that the parser yields expected expressions when faced with the token stream produced
+/// from the given string. Panic if this is not so.
+fn verify_parser_output<B: Build>(input: &str, expected: B) {
+    let pool = InternPool::new();
+
+    let actual = process_test_string(input, &pool);
+
+    match actual.len() {
+        0 => panic!("parser did not produce output"),
+        1 => { /* okay */ },
+        _ => panic!("parser is not exhausted after parsing the whole token stream"),
+    }
+
+    let expected = expected.build_with(&pool);
+
+    assert!(verify_expression(actual.first().unwrap(), &expected, &pool));
+}
+
+/// Verify that the parser fails to recover from errors present in the given string and does not
+/// produce any output. Panics if the parser outputs something.
+fn verify_parser_failure(input: &str) {
+    let pool = InternPool::new();
+
+    let actual = process_test_string(input, &pool);
+
+    assert!(actual.is_empty());
+}
+
+/// Tokenize and parse the given strings. Return the expressions produced by the parser.
+fn process_test_string(string: &str, pool: &InternPool) -> Vec<Expression> {
+    let scanner_diagnostics = Rc::new(RefCell::new(Vec::new()));
+    let scanner_reporter = SinkReporter::new(scanner_diagnostics.clone());
+    let scanner_handler = Handler::with_reporter(Box::new(scanner_reporter));
+
+    let tokens = StringScanner::new(string, &pool, &scanner_handler);
+
+    let parser_diagnostics = Rc::new(RefCell::new(Vec::new()));
+    let parser_reporter = SinkReporter::new(parser_diagnostics.clone());
+    let parser_handler = Handler::with_reporter(Box::new(parser_reporter));
+
+    let mut parser = Parser::new(tokens, &pool, &parser_handler);
+
+    let mut exprs = Vec::new();
+
+    while let Some(expr) = parser.parse_all() {
+        exprs.push(expr);
+    }
+
+    return exprs;
+}
+
+/// Compare actual parsing results to expected. Return true if they match.
+fn verify_expression(actual: &Expression, expected: &Expression, _: &InternPool) -> bool {
+    expression_diff::compare(actual, expected) == ComparisonResult::Identical
+}

--- a/src/libsyntax/tests/utils/diff/mod.rs
+++ b/src/libsyntax/tests/utils/diff/mod.rs
@@ -4,10 +4,8 @@
 // This file may be copied, distributed, and modified only in accordance
 // with the terms specified by this license.
 
-//! Test utilities.
+//! Computing differences.
 //!
-//! Here we gather miscellaneous utility code that is used throughout our test harness.
+//! Various code for computing diffs between entities.
 
-pub mod diff;
-pub mod iter;
-pub mod stubs;
+pub mod sequence;

--- a/src/libsyntax/tests/utils/diff/mod.rs
+++ b/src/libsyntax/tests/utils/diff/mod.rs
@@ -9,3 +9,4 @@
 //! Various code for computing diffs between entities.
 
 pub mod sequence;
+pub mod tree;

--- a/src/libsyntax/tests/utils/diff/sequence.rs
+++ b/src/libsyntax/tests/utils/diff/sequence.rs
@@ -1,0 +1,324 @@
+// Copyright (c) 2016, ilammy
+//
+// Licensed under MIT license (see LICENSE file in the root directory).
+// This file may be copied, distributed, and modified only in accordance
+// with the terms specified by this license.
+
+//! Diffing sequences.
+
+/// Result of sequence element comparison.
+#[derive(Debug, PartialEq)]
+pub enum Diff<'a, T> where T: 'a {
+    /// The element is present only in the left sequence.
+    Left(&'a T),
+
+    /// The element is present only in the right sequence.
+    Right(&'a T),
+
+    /// Matching elements in the left and right sequences are equal.
+    Equal(&'a T, &'a T),
+
+    /// Matching elements in the left and right sequences are not equal.
+    Replace(&'a T, &'a T),
+}
+
+/// Compute the difference between two sequences of comparable elements.
+pub fn diff<'a, T: Eq>(lhs: &'a [T], rhs: &'a [T]) -> Vec<Diff<'a, T>> {
+    diff_with(lhs, rhs, &|lhs, rhs| lhs == rhs)
+}
+
+// Here we use the classical approach to computing diffs. First we find the longest common
+// subsequences of all sequence prefixes using dynamic programming. Then we derive the diff
+// from this data. The algorithm has O(n^2) complexity by its nature, and element comparisons
+// may be expensive, so we take care to reduce the amount of work to be done.
+
+/// Compute the difference between two sequences using the provided comparator.
+pub fn diff_with<'a, T>(lhs: &'a[T], rhs: &'a[T], equal: &Fn(&T, &T) -> bool)
+    -> Vec<Diff<'a, T>>
+{
+    let fwd = lhs.iter().zip(rhs.iter());
+    let rev = lhs.iter().rev().zip(rhs.iter().rev());
+
+    // It is common for sequences being diffed to have equal prefixes and/or suffixes. We use
+    // an O(n^2) algorithm to actually compute the diff, so we would like to minimize the size
+    // of input data. One way to do this is to strip the equal prefix and suffix from sequences.
+
+    let prefix = fwd.take_while(|&(lhs, rhs)| equal(lhs, rhs))
+                    .map(|(lhs, rhs)| Diff::Equal(lhs, rhs))
+                    .collect::<Vec<_>>();
+
+    // We may even get lucky and find out that the sequences are in fact equal.
+    if (lhs.len() == rhs.len()) && (prefix.len() == lhs.len()) {
+        return prefix;
+    }
+
+    let suffix = rev.take_while(|&(lhs, rhs)| equal(lhs, rhs))
+                    .map(|(lhs, rhs)| Diff::Equal(lhs, rhs))
+                    .collect::<Vec<_>>();
+
+    // Otherwise, we now have the prefix and the (reversed) suffix. Compute the actual diff for
+    // the sequence slices that are different.
+
+    let lhs = &lhs[prefix.len()..(lhs.len() - suffix.len())];
+    let rhs = &rhs[prefix.len()..(rhs.len() - suffix.len())];
+
+    let diff = compute_diff(lhs, rhs, equal);
+
+    // Finally, compute the resulting full diff by concatenating prefix, diff, and suffix.
+    // Note that the diff and suffix are stored in reverse order so we must reverse them back.
+    // Also not that drain() requires mutable references so we redeclare all stuff as mutable.
+
+    let mut prefix = prefix;
+    let mut suffix = suffix;
+    let mut diff   = diff;
+
+    return prefix.drain(..)
+                 .chain(diff.drain(..).rev())
+                 .chain(suffix.drain(..).rev())
+                 .collect();
+}
+
+/// Actually compute the diff between the sequences using the provided comparator.
+fn compute_diff<'a, T>(lhs: &'a[T], rhs: &'a[T], equal: &Fn(&T, &T) -> bool)
+    -> Vec<Diff<'a, T>>
+{
+    let (lcs, eqv) = compute_lcs_lookup(lhs, rhs, equal);
+
+    return backtrace_diff(lhs, rhs, &lcs, &eqv);
+}
+
+/// Compute the longest common subsequence lookup matrix.
+///
+/// Returns an `(lhs.len() + 1) * (rhs.len() + 1)` matrix C where C[i, j] contains
+/// the length of the longest common subsequence of `lhs[0..i]` and `rhs[0..j]`.
+///
+/// Also returns the matrix E of the same size which contains results of performed
+/// element comparisons. The first row and column are filled with `false`.
+///
+/// The matrices are represented with just Vecs. You have to compute offsets manually.
+/// Thanks for having built-in array support, Rust!
+fn compute_lcs_lookup<T>(lhs: &[T], rhs: &[T], equal: &Fn(&T, &T) -> bool)
+    -> (Vec<usize>, Vec<bool>)
+{
+    use std::cmp::max;
+
+    let h = lhs.len() + 1;
+    let w = rhs.len() + 1;
+
+    let mut c = Vec::with_capacity(w * h);
+    let mut e = Vec::with_capacity(w * h);
+
+    c.resize(w * h, 0);
+    e.resize(w * h, false);
+
+    for i in 0..lhs.len() {
+        for j in 0..rhs.len() {
+            if equal(&lhs[i], &rhs[j]) {
+                e[w * (i + 1) + (j + 1)] = true;
+                c[w * (i + 1) + (j + 1)] = c[w * i + j] + 1;
+            } else {
+                e[w * (i + 1) + (j + 1)] = false;
+                c[w * (i + 1) + (j + 1)] = max(c[w * (i + 1) + j], c[w * i + (j + 1)]);
+            }
+        }
+    }
+
+    return (c, e);
+}
+
+/// Backtrace the longest common subsequence lookup matrix, computing a diff.
+///
+/// This is rather convoluted backtracking. The idea behind it is that every path in the LCS
+/// matrix from the top-left corner to the bottom-right corner corresponds to a certain diff.
+/// We are interested in the shortest diff. We can use a greedy algorithm to find the shortest
+/// path by exploiting the fact that the length of the longest common subsequence does not
+/// increase when elements are removed from the end of the sequences. This allows us to trace
+/// the optimal path in reverse order.
+///
+/// Refer to any book on dynamic programming for a better explanation of how this works.
+fn backtrace_diff<'a, T>(lhs: &'a [T], rhs: &'a [T],
+                         lcs: &[usize], eqv: &[bool]) -> Vec<Diff<'a, T>>
+{
+    let h = lhs.len() + 1;
+    let w = rhs.len() + 1;
+
+    assert_eq!(lcs.len(), w * h);
+    assert_eq!(eqv.len(), w * h);
+
+    let mut diff = Vec::with_capacity(lhs.len() + rhs.len());
+
+    let mut i = lhs.len();
+    let mut j = rhs.len();
+
+    while (i != 0) || (j != 0) {
+        if (i > 0) && (j > 0) {
+            let len_a = lcs[w * (i - 1) + j];
+            let len_b = lcs[w * i + (j - 1)];
+
+            if len_a == len_b {
+                if eqv[w * i + j] {
+                    diff.push(Diff::Equal(&lhs[i - 1], &rhs[j - 1]));
+                } else {
+                    diff.push(Diff::Replace(&lhs[i - 1], &rhs[j - 1]));
+                }
+                i -= 1;
+                j -= 1;
+            } else if len_a < len_b {
+                diff.push(Diff::Right(&rhs[j - 1]));
+                j -= 1;
+            } else {
+                diff.push(Diff::Left(&lhs[i - 1]));
+                i -= 1;
+            }
+        } else if i == 0 {
+            diff.push(Diff::Right(&rhs[j - 1]));
+            j -= 1;
+        } else if j == 0 {
+            diff.push(Diff::Left(&lhs[i - 1]));
+            i -= 1;
+        }
+    }
+
+    return diff;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty() {
+        let a: Vec<i32> = vec![];
+        let b: Vec<i32> = vec![];
+
+        let diff = diff(&a, &b);
+
+        assert!(diff.is_empty());
+    }
+
+    #[test]
+    fn partially_empty_1() {
+        let a: Vec<i32> = vec![1, 2, 3];
+        let b: Vec<i32> = vec![];
+
+        let diff = diff(&a, &b);
+
+        assert_eq!(diff, vec![
+            Diff::Left (&a[0]), // -1
+            Diff::Left (&a[1]), // -2
+            Diff::Left (&a[2]), // -3
+        ]);
+    }
+
+    #[test]
+    fn partially_empty_2() {
+        let a: Vec<i32> = vec![];
+        let b: Vec<i32> = vec![1, 2, 3];
+
+        let diff = diff(&a, &b);
+
+        assert_eq!(diff, vec![
+            Diff::Right (&b[0]), // +1
+            Diff::Right (&b[1]), // +2
+            Diff::Right (&b[2]), // +3
+        ]);
+    }
+
+    #[test]
+    fn equal() {
+        let a = vec![1, 2, 3];
+        let b = vec![1, 2, 3];
+
+        let diff = diff(&a, &b);
+
+        assert_eq!(diff, vec![
+            Diff::Equal (&a[0], &b[0]), // 1
+            Diff::Equal (&a[1], &b[1]), // 2
+            Diff::Equal (&a[2], &b[2]), // 3
+        ]);
+    }
+
+    #[test]
+    fn different_1() {
+        let a = vec![1, 2,    3, 4, 5, 6, 7, 8, 2   ];
+        let b = vec![8, 2, 4, 3, 1, 1, 6, 7, 5, 2, 3];
+        //           |     +     |  |        |     +
+
+        let diff = diff(&a, &b);
+
+        assert_eq!(diff, vec![
+            Diff::Replace (&a[0], &b[0]),  // -1  +8
+            Diff::Equal   (&a[1], &b[1]),  //  2   2
+            Diff::Right   (       &b[2]),  //     +4
+            Diff::Equal   (&a[2], &b[3]),  //  3   3
+            Diff::Replace (&a[3], &b[4]),  // -4  +1
+            Diff::Replace (&a[4], &b[5]),  // -5  +1
+            Diff::Equal   (&a[5], &b[6]),  //  6   6
+            Diff::Equal   (&a[6], &b[7]),  //  7   7
+            Diff::Replace (&a[7], &b[8]),  // -8  +5
+            Diff::Equal   (&a[8], &b[9]),  //  2   2
+            Diff::Right   (       &b[10]), //     +3
+        ]);
+    }
+
+    #[test]
+    fn different_2() {
+        let a = vec!['O','h','a','i',',',' ',    'I',' ','a',    'm',' ','B','o','b'    ];
+        let b = vec![        'H','i',',',' ','w','e',' ','a','r','e',' ','B','o','b','!'];
+        //            -   -   |               +   |           +   |                   +
+
+        let diff = diff(&a, &b);
+
+        assert_eq!(diff, vec![
+            Diff::Left    (&a[0]         ), // -O
+            Diff::Left    (&a[1]         ), // -h
+            Diff::Replace (&a[2],  &b[0] ), // -a  +H
+            Diff::Equal   (&a[3],  &b[1] ), //  i   i
+            Diff::Equal   (&a[4],  &b[2] ), //  ,   ,
+            Diff::Equal   (&a[5],  &b[3] ), //
+            Diff::Right   (        &b[4] ), //     +w
+            Diff::Replace (&a[6],  &b[5] ), // -I  +e
+            Diff::Equal   (&a[7],  &b[6] ), //
+            Diff::Equal   (&a[8],  &b[7] ), //  a   a
+            Diff::Right   (        &b[8] ), //     +r
+            Diff::Replace (&a[9],  &b[9] ), // -m  +e
+            Diff::Equal   (&a[10], &b[10]), //
+            Diff::Equal   (&a[11], &b[11]), //  B   B
+            Diff::Equal   (&a[12], &b[12]), //  o   o
+            Diff::Equal   (&a[13], &b[13]), //  b   b
+            Diff::Right   (        &b[14]), //     +!
+        ]);
+    }
+
+    #[test]
+    fn different_3() {
+        let a = vec!["foo", "bar", "baz"];
+        let b = vec!["foo", "BAR", "baz"];
+        //                    |
+
+        let diff = diff(&a, &b);
+
+        assert_eq!(diff, vec![
+            Diff::Equal   (&a[0],  &b[0] ), //  "foo"  "foo"
+            Diff::Replace (&a[1],  &b[1] ), // -"bar" +"BAR"
+            Diff::Equal   (&a[2],  &b[2] ), //  "baz"  "baz"
+        ]);
+    }
+
+    #[test]
+    fn custom_comparator() {
+        let a: Vec<i32> = vec![0, -1,  2, -3    ];
+        let b: Vec<i32> = vec![    1, -2,  3, -4];
+        //                     -               +
+
+        let diff = diff_with(&a, &b, &|a, b| a.abs() == b.abs());
+
+        assert_eq!(diff, vec![
+            Diff::Left  (&a[0]       ), // -[ 0]
+            Diff::Equal (&a[1], &b[0]), //  [-1]  [ 1]
+            Diff::Equal (&a[2], &b[1]), //  [ 2]  [-2]
+            Diff::Equal (&a[3], &b[2]), //  [-3]  [ 3]
+            Diff::Right (       &b[3]), //       +[-4]
+        ]);
+    }
+}

--- a/src/libsyntax/tests/utils/diff/tree.rs
+++ b/src/libsyntax/tests/utils/diff/tree.rs
@@ -1,0 +1,312 @@
+// Copyright (c) 2016, ilammy
+//
+// Licensed under MIT license (see LICENSE file in the root directory).
+// This file may be copied, distributed, and modified only in accordance
+// with the terms specified by this license.
+
+//! Diffing trees.
+//!
+//! Trees are more complex than sequences. Slices are enough to represent diffable sequences, but
+//! for trees we need to know the internal structure of their nodes. One will need to provide an
+//! implementation of the `TreeNode` trait which provides access to child nodes of a given node.
+//!
+//! Also, tree diff expects that provided comparators or `Eq` implementation compare only immediate
+//! labels of the nodes, without doing a deep comparison of their child nodes. Failure to observe
+//! this expectation results into over-conservative diffs (though, they are _not_ incorrect). Know
+//! that derived implementations of `Eq` usually do a deep comparison, so you will usually need to
+//! write an explicit comparator anyway.
+
+use utils::diff::sequence;
+use utils::tree::{TreeNode};
+
+/// Result of tree node comparison.
+#[derive(Debug, PartialEq)]
+pub enum Diff<'a, T> where T: 'a {
+    /// Node is present only in the left tree.
+    Left(&'a T),
+
+    /// Node is present only in the right tree.
+    Right(&'a T),
+
+    /// Corresponding nodes are equal (and we can compare their children).
+    Equal(&'a T, &'a T, Vec<Diff<'a, T>>),
+
+    /// Corresponding nodes are not equal.
+    Replace(&'a T, &'a T),
+}
+
+/// Compute the flat difference between two trees of comparable elements.
+///
+/// See [`flat_diff_with`](fn.flat_diff_with.html) for an explanation of what _flat_ means.
+pub fn flat_diff<'a, T: TreeNode + Eq>(lhs: &'a T, rhs: &'a T) -> Diff<'a, T> {
+    flat_diff_with(lhs, rhs, &|lhs, rhs| lhs == rhs)
+}
+
+/// Compute the flat difference between two tree using the provided comparator.
+///
+/// This function computes a _flat_ difference, meaning that it simply compares trees from root
+/// to leaves in breadth-first fashion until the first difference is met, and sibling nodes are
+/// compared with a sequence diff algorithm. The most prominent implication of all this is that
+/// this algorithm fails to notice node movement.
+///
+/// While such awareness is sometimes desired, it has much more significant computation cost.
+/// More precise algorithms for computing tree edit distance (e.g. Zhang-Shasha) have O(n1 * n2)
+/// complexity, where n1 and n2 are amounts of nodes in the trees. This algorithm, however, has
+/// O((n1 + n2) * (m1 * m2)) complexity, where m1 and m2 are maximum number of child nodes in the
+/// trees (which are usually small). Thus it is much more efficient at comparing mostly equivalent
+/// syntax trees with minor number of errors. Finally, flat diff is much more suitable for textual
+/// presentation, as it captures only horizontal movements of nodes on the same level.
+///
+/// Example:
+///
+/// ```plaintext
+///         A              A               A
+///         |- B           |- B            |- B
+///         |  |- D        |  |- E         |  |- (-) D
+///         |  |  |- G     |  |- Q         |  |- E
+/// diff (  |  |  `- H  ,  |  `- F   )  =  |  |- (+) Q
+///         |  |- E        `- C            |  `- F
+///         |  `- F           `- D         `- C
+///         `- C                 |- G         `- (+) D
+///                              |  `- J
+///                              `- H
+/// ```
+pub fn flat_diff_with<'a, T>(lhs: &'a T, rhs: &'a T, equal: &Fn(&T, &T) -> bool) -> Diff<'a, T>
+    where T: TreeNode
+{
+    if equal(lhs, rhs) {
+        Diff::Equal(lhs, rhs, flat_child_diff(lhs, rhs, equal))
+    } else {
+        Diff::Replace(lhs, rhs)
+    }
+}
+
+fn flat_child_diff<'a, T>(lhs: &'a T, rhs: &'a T, equal: &Fn(&T, &T) -> bool) -> Vec<Diff<'a, T>>
+    where T: TreeNode
+{
+    let lhs_children = lhs.children();
+    let rhs_children = rhs.children();
+
+    sequence::diff_with(&lhs_children, &rhs_children, &|lhs, rhs| equal(lhs, rhs))
+        .iter()
+        .map(|diff| match *diff {
+            sequence::Diff::Left(lhs) => {
+                self::Diff::Left(*lhs)
+            }
+            sequence::Diff::Right(rhs) => {
+                self::Diff::Right(*rhs)
+            }
+            sequence::Diff::Replace(lhs, rhs) => {
+                self::Diff::Replace(*lhs, *rhs)
+            }
+            sequence::Diff::Equal(lhs, rhs) => {
+                self::Diff::Equal(*lhs, *rhs, flat_child_diff(*lhs, *rhs, equal))
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ops::Index;
+    use utils::tree::{TreeNode};
+
+    #[derive(Debug, Eq)]
+    struct Tree<T> {
+        value: T,
+        children: Vec<Tree<T>>,
+    }
+
+    impl<T> PartialEq for Tree<T> where T: PartialEq {
+        fn eq(&self, other: &Self) -> bool {
+            self.value == other.value
+        }
+    }
+
+    impl<T> TreeNode for Tree<T> {
+        fn children<'a>(&'a self) -> Vec<&'a Self> {
+            self.children.iter().collect()
+        }
+    }
+
+    impl<T> Tree<T> {
+        fn new(value: T, children: Vec<Tree<T>>) -> Tree<T> {
+            Tree { value: value, children: children }
+        }
+    }
+
+    impl<T> Index<usize> for Tree<T> {
+        type Output = Tree<T>;
+
+        fn index(&self, index: usize) -> &Self::Output {
+            &self.children[index]
+        }
+    }
+
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Flat diff
+
+    #[test]
+    fn root_not_equal() {
+        let a = Tree::new(1, vec![]);
+        let b = Tree::new(2, vec![]);
+
+        assert_eq!(flat_diff(&a, &b), Diff::Replace(&a, &b));
+    }
+
+    #[test]
+    fn root_not_equal_children_equal() {
+        let a = Tree::new(1, vec![Tree::new(2, vec![]), Tree::new(3, vec![])]);
+        let b = Tree::new(2, vec![Tree::new(2, vec![]), Tree::new(3, vec![])]);
+
+        assert_eq!(flat_diff(&a, &b), Diff::Replace(&a, &b));
+    }
+
+    #[test]
+    fn root_equal() {
+        let a = Tree::new(1, vec![]);
+        let b = Tree::new(1, vec![]);
+
+        assert_eq!(flat_diff(&a, &b), Diff::Equal(&a, &b, vec![]));
+    }
+
+    #[test]
+    fn root_equal_children_equal() {
+        let a = Tree::new(1, vec![Tree::new(2, vec![]), Tree::new(3, vec![])]);
+        let b = Tree::new(1, vec![Tree::new(2, vec![]), Tree::new(3, vec![])]);
+
+        assert_eq!(flat_diff(&a, &b),
+            Diff::Equal(&a, &b, vec![
+                Diff::Equal(&a[0], &b[0], vec![]),
+                Diff::Equal(&a[1], &b[1], vec![]),
+            ])
+        );
+    }
+
+    #[test]
+    fn children_diff_1() {
+        let a = Tree::new(1, vec![Tree::new(2, vec![])]);
+        let b = Tree::new(1, vec![Tree::new(2, vec![]), Tree::new(3, vec![])]);
+
+        assert_eq!(flat_diff(&a, &b),
+            Diff::Equal(&a, &b, vec![
+                Diff::Equal(&a[0], &b[0], vec![]),
+                Diff::Right(&b[1]),
+            ])
+        );
+    }
+
+    #[test]
+    fn children_diff_2() {
+        let a = Tree::new(1, vec![Tree::new(2, vec![]), Tree::new(3, vec![])]);
+        let b = Tree::new(1, vec![Tree::new(2, vec![])]);
+
+        assert_eq!(flat_diff(&a, &b),
+            Diff::Equal(&a, &b, vec![
+                Diff::Equal(&a[0], &b[0], vec![]),
+                Diff::Left(&a[1]),
+            ])
+        );
+    }
+
+    #[test]
+    fn children_diff_3() {
+        let a = Tree::new(1, vec![Tree::new(2, vec![])]);
+        let b = Tree::new(1, vec![Tree::new(3, vec![])]);
+
+        assert_eq!(flat_diff(&a, &b),
+            Diff::Equal(&a, &b, vec![
+                Diff::Replace(&a[0], &b[0]),
+            ])
+        );
+    }
+
+    #[test]
+    fn children_diff_deep() {
+        let a = Tree::new(1, vec![
+            Tree::new(2, vec![
+                Tree::new(3, vec![
+                    Tree::new(4, vec![]),
+                ]),
+                Tree::new(5, vec![
+                    Tree::new(6, vec![]),
+                    Tree::new(7, vec![]),
+                ]),
+                Tree::new(8, vec![
+                    Tree::new(9, vec![]),
+                    Tree::new(10, vec![]),
+                ]),
+                Tree::new(11, vec![]),
+            ]),
+            Tree::new(12, vec![
+                Tree::new(13, vec![
+                    Tree::new(14, vec![]),
+                ]),
+            ]),
+            Tree::new(15, vec![]),
+        ]);
+        let b = Tree::new(1, vec![
+            Tree::new(2, vec![
+                Tree::new(3, vec![
+                    Tree::new(4, vec![]),
+                    Tree::new(6, vec![]),
+                ]),
+                Tree::new(5, vec![
+                    Tree::new(7, vec![]),
+                ]),
+                Tree::new(8, vec![
+                    Tree::new(9, vec![
+                        Tree::new(20, vec![]),
+                        Tree::new(21, vec![
+                            Tree::new(22, vec![]),
+                        ]),
+                    ]),
+                    Tree::new(10, vec![]),
+                ]),
+                Tree::new(11, vec![]),
+            ]),
+            Tree::new(18, vec![]),
+            Tree::new(12, vec![
+                Tree::new(13, vec![
+                    Tree::new(15, vec![]),
+                ]),
+            ]),
+            Tree::new(19, vec![]),
+            Tree::new(17, vec![]),
+            Tree::new(16, vec![]),
+        ]);
+
+        assert_eq!(flat_diff(&a, &b),
+            Diff::Equal(&a, &b, vec![
+                Diff::Equal(&a[0], &b[0], vec![
+                    Diff::Equal(&a[0][0], &b[0][0], vec![
+                        Diff::Equal(&a[0][0][0], &b[0][0][0], vec![]),
+                        Diff::Right(&b[0][0][1]),
+                    ]),
+                    Diff::Equal(&a[0][1], &b[0][1], vec![
+                        Diff::Left (&a[0][1][0]),
+                        Diff::Equal(&a[0][1][1], &b[0][1][0], vec![]),
+                    ]),
+                    Diff::Equal(&a[0][2], &b[0][2], vec![
+                        Diff::Equal(&a[0][2][0], &b[0][2][0], vec![
+                            Diff::Right(&b[0][2][0][0]),
+                            Diff::Right(&b[0][2][0][1]),
+                        ]),
+                        Diff::Equal(&a[0][2][1], &b[0][2][1], vec![]),
+                    ]),
+                    Diff::Equal(&a[0][3], &b[0][3], vec![]),
+                ]),
+                Diff::Right(&b[1]),
+                Diff::Equal(&a[1], &b[2], vec![
+                    Diff::Equal(&a[1][0], &b[2][0], vec![
+                        Diff::Replace(&a[1][0][0], &b[2][0][0]),
+                    ]),
+                ]),
+                Diff::Right(&b[3]),
+                Diff::Right(&b[4]),
+                Diff::Replace(&a[2], &b[5]),
+            ])
+        );
+    }
+}

--- a/src/libsyntax/tests/utils/expression_builders.rs
+++ b/src/libsyntax/tests/utils/expression_builders.rs
@@ -1,0 +1,163 @@
+// Copyright (c) 2016, ilammy
+//
+// Licensed under MIT license (see LICENSE file in the root directory).
+// This file may be copied, distributed, and modified only in accordance
+// with the terms specified by this license.
+
+//! Test utilities: expression builders.
+//!
+//! This module contains utilities for building `Expression`s.
+
+use syntax::diagnostics::{Span};
+use syntax::expressions::{Expression, ExpressionKind};
+use syntax::intern_pool::{InternPool};
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Build trait
+//
+
+/// Lazily buildable expression.
+///
+/// This is used to build `Expression` instances which user proper `Atom`s for named things
+/// while using just strings in test code.
+pub trait Build {
+    /// Render this buildable expression.
+    fn build_with(&self, pool: &InternPool) -> Expression;
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Helper functions
+//
+
+/// Build an expression with dummy span.
+fn build_expression(kind: ExpressionKind) -> Expression {
+    Expression {
+        kind: kind,
+        span: Span::new(0, 0),
+    }
+}
+
+/// Build a vec of an expressions.
+fn build_vec(vec: &Vec<Box<Build>>, pool: &InternPool) -> Vec<Expression> {
+    vec.iter().map(|ref e| e.build_with(pool)).collect()
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Buildable expressions
+//
+
+/// A delayed ExpressionKind::Unrecognized.
+pub struct Unrecognized;
+
+impl Unrecognized {
+    /// Make a new Unrecognized.
+    pub fn new() -> Unrecognized {
+        Unrecognized
+    }
+}
+
+impl Build for Unrecognized {
+    fn build_with(&self, _: &InternPool) -> Expression {
+        build_expression(
+            ExpressionKind::Unrecognized)
+    }
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+/// A delayed ExpressionKind::ImplicitModule.
+pub struct ImplicitModule {
+    body: Vec<Box<Build>>,
+}
+
+impl ImplicitModule {
+    /// Make a new ImplicitModule with an empty body.
+    pub fn new() -> ImplicitModule {
+        ImplicitModule {
+            body: Vec::new(),
+        }
+    }
+
+    /// Add a buildable expression to this module's body.
+    pub fn push<E: Build + 'static>(mut self, e: E) -> Self {
+        self.body.push(Box::new(e));
+        self
+    }
+}
+
+impl Build for ImplicitModule {
+    fn build_with(&self, pool: &InternPool) -> Expression {
+        build_expression(
+            ExpressionKind::ImplicitModule {
+                body: build_vec(&self.body, pool),
+        })
+    }
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+/// A delayed ExpressionKind::Library.
+pub struct Library {
+    name: String,
+    body: Vec<Box<Build>>,
+}
+
+impl Library {
+    /// Make a new Library with an empty body and a given name.
+    pub fn new(name: &str) -> Library {
+        Library {
+            name: name.to_owned(),
+            body: Vec::new(),
+        }
+    }
+
+    /// Add a buildable expression to this library's body.
+    pub fn push<E: Build + 'static>(mut self, e: E) -> Self {
+        self.body.push(Box::new(e));
+        self
+    }
+}
+
+impl Build for Library {
+    fn build_with(&self, pool: &InternPool) -> Expression {
+        build_expression(
+            ExpressionKind::Library {
+                name: pool.intern(&self.name),
+                body: build_vec(&self.body, pool),
+        })
+    }
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+/// A delayed ExpressionKind::Module.
+pub struct Module {
+    name: String,
+    body: Vec<Box<Build>>,
+}
+
+impl Module {
+    /// Make a new Module with an empty body and a given name.
+    pub fn new(name: &str) -> Module {
+        Module {
+            name: name.to_owned(),
+            body: Vec::new(),
+        }
+    }
+
+    /// Add a buildable expression to this module's body.
+    pub fn push<E: Build + 'static>(mut self, e: E) -> Self {
+        self.body.push(Box::new(e));
+        self
+    }
+}
+
+impl Build for Module {
+    fn build_with(&self, pool: &InternPool) -> Expression {
+        build_expression(
+            ExpressionKind::Module {
+                name: pool.intern(&self.name),
+                body: build_vec(&self.body, pool),
+        })
+    }
+}

--- a/src/libsyntax/tests/utils/expression_diff.rs
+++ b/src/libsyntax/tests/utils/expression_diff.rs
@@ -1,0 +1,106 @@
+// Copyright (c) 2016, ilammy
+//
+// Licensed under MIT license (see LICENSE file in the root directory).
+// This file may be copied, distributed, and modified only in accordance
+// with the terms specified by this license.
+
+//! Test utilities: expression diff.
+//!
+//! This module contains utilities for comparing `Expression`s.
+
+use syntax::expressions::{Expression, ExpressionKind};
+
+/// Result of expression comparison.
+#[derive(PartialEq, Eq)]
+pub enum ComparisonResult {
+    /// Expressions are fully identical.
+    Identical,
+
+    /// Types of the expressions match, but the contents don't.
+    Matching,
+
+    /// Types of the expressions do not match.
+    Different,
+}
+
+/// Match two tree-structured enum references.
+///
+/// The delimiter syntax is kinda quirky, but that's Rust macros for you. Deal with it.
+/// Copypasting matches is much more convoluted. The macro enforces full coverage of
+/// enum variant pairs, so you can't miss them.
+macro_rules! unify_match {
+    (($actual_term:expr, $expected_term:expr) => {
+        $(
+            $variant:path {
+                $($field:ident: ($actual_name:ident, $expected_name:ident)),*
+            } => $then_body:block
+        ),*
+        ; else $else_body:block
+    }) => {
+        match $actual_term {
+        $(
+            &$variant { $($field: ref $actual_name,)* } => {
+                match $expected_term {
+                    &$variant { $($field: ref $expected_name,)* } => $then_body
+                    _ => $else_body
+                }
+            }
+        )*
+        }
+    };
+}
+
+/// Compare contents of two expressionss while ignoring their spans.
+pub fn compare(actual: &Expression, expected: &Expression) -> ComparisonResult {
+    unify_match!((&actual.kind, &expected.kind) => {
+        ExpressionKind::ImplicitModule {
+            body: (body_a, body_e)
+        } => {
+            compare_slices(body_a, body_e)
+        },
+        ExpressionKind::Library {
+            name: (name_a, name_e),
+            body: (body_a, body_e)
+        } => {
+            if name_a != name_e {
+                ComparisonResult::Matching
+            } else {
+                compare_slices(body_a, body_e)
+            }
+        },
+        ExpressionKind::Module {
+            name: (name_a, name_e),
+            body: (body_a, body_e)
+        } => {
+            if name_a != name_e {
+                ComparisonResult::Matching
+            } else {
+                compare_slices(body_a, body_e)
+            }
+        },
+        ExpressionKind::Unrecognized {} => { ComparisonResult::Identical };
+        else {
+            ComparisonResult::Different
+        }
+    })
+}
+
+/// Compare two expression sequences.
+///
+/// Note that this cannot return ComparisonResult::Different.
+fn compare_slices(actual: &[Expression], expected: &[Expression]) -> ComparisonResult {
+    if actual.len() != expected.len() {
+        return ComparisonResult::Matching;
+    }
+
+    for (ref actual, ref expected) in actual.iter().zip(expected.iter()) {
+        match compare(actual, expected) {
+            ComparisonResult::Different | ComparisonResult::Matching => {
+                return ComparisonResult::Matching;
+            }
+            ComparisonResult::Identical => { continue; }
+        }
+    }
+
+    return ComparisonResult::Identical;
+}

--- a/src/libsyntax/tests/utils/iter.rs
+++ b/src/libsyntax/tests/utils/iter.rs
@@ -1,0 +1,49 @@
+// Copyright (c) 2016, ilammy
+//
+// Licensed under MIT license (see LICENSE file in the root directory).
+// This file may be copied, distributed, and modified only in accordance
+// with the terms specified by this license.
+
+//! Iterator utilities.
+
+use std::iter::Iterator;
+
+/// Non-short-circuiting version of `Zip`. See `longest_zip()` for details.
+pub struct LongestZip<A, B> {
+    a: A,
+    b: B,
+}
+
+impl<A, B> Iterator for LongestZip<A, B> where A: Iterator, B: Iterator {
+    type Item = (Option<A::Item>, Option<B::Item>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let v_a = self.a.next();
+        let v_b = self.b.next();
+
+        if v_a.is_some() || v_b.is_some() {
+            return Some((v_a, v_b));
+        } else {
+            return None;
+        }
+    }
+}
+
+/// Returns an iterator which simulataneously walks over two other iterators until _both_ of
+/// them are exhausted. It is similar to `zip()` method of `Iterator`, but it does not stop
+/// when one of the iterators in exhausted.
+///
+/// Example:
+/// ```
+/// assert_eq!(longest_zip(&[1, 2, 3], &[5, 6]).collect::<Vec<_>>(),
+///     &[
+///         (Some(&1), Some(&5)),
+///         (Some(&2), Some(&6)),
+///         (Some(&3), None)
+///     ]);
+/// ```
+pub fn longest_zip<A, B>(iter1: A, iter2: B) -> LongestZip<A::IntoIter, B::IntoIter>
+    where A: IntoIterator, B: IntoIterator
+{
+    LongestZip { a: iter1.into_iter(), b: iter2.into_iter() }
+}

--- a/src/libsyntax/tests/utils/mod.rs
+++ b/src/libsyntax/tests/utils/mod.rs
@@ -10,5 +10,6 @@
 
 pub mod diff;
 pub mod iter;
+pub mod pretty_tree;
 pub mod stubs;
 pub mod tree;

--- a/src/libsyntax/tests/utils/mod.rs
+++ b/src/libsyntax/tests/utils/mod.rs
@@ -1,0 +1,12 @@
+// Copyright (c) 2016, ilammy
+//
+// Licensed under MIT license (see LICENSE file in the root directory).
+// This file may be copied, distributed, and modified only in accordance
+// with the terms specified by this license.
+
+//! Test utilities.
+//!
+//! Here we gather miscellaneous utility code that is used throughout our test harness.
+
+pub mod iter;
+pub mod stubs;

--- a/src/libsyntax/tests/utils/pretty_tree.rs
+++ b/src/libsyntax/tests/utils/pretty_tree.rs
@@ -1,0 +1,283 @@
+// Copyright (c) 2016, ilammy
+//
+// Licensed under MIT license (see LICENSE file in the root directory).
+// This file may be copied, distributed, and modified only in accordance
+// with the terms specified by this license.
+
+//! Pretty-printing trees.
+//!
+//! This module provides a facility for pretty-printing trees in a format similar to Clang:
+//!
+//! ```plaintext
+//! root
+//! |- child node
+//! `- more children
+//!    |- which can have
+//!    |  `- their own children
+//!    `- and so on
+//! ```
+//!
+//! Users must implement the `TreeNode` trait for their data to describe the tree structure.
+//! Actual formatting of individual nodes may be performed in several ways:
+//!
+//!   - Implement the `DisplayTreeNode` trait (exported by this module).
+//!
+//!     This trait is similar to the usual `fmt::Display`. It requires identical interface
+//!     based on `fmt::Formatter`, and is suitable when your nodes have some canonical
+//!     representation which you will be using 99% of time.
+//!
+//!   - Explicitly specify the way to format your nodes.
+//!
+//!     This is convenient when you need to use multiple representations of tree nodes.
+//!     Just write a formatting function for each of your representations.
+//!
+//! The pretty-printer can handle multiline node representations, but it will normalize all
+//! newlines into just `\n`.
+
+use std::fmt;
+use utils::tree::{TreeNode};
+
+/// Formatting trait for trees.
+///
+/// This trait is similar to `fmt::Display` and its friends from `std::fmt`.
+pub trait DisplayTreeNode {
+    /// Formats this node using the given formatter.
+    fn fmt(&self, &mut fmt::Formatter) -> fmt::Result;
+}
+
+/// Format a tree into a string.
+pub fn format<T>(tree: &T) -> String
+    where T: DisplayTreeNode + TreeNode
+{
+    let mut string = String::new();
+    let _ = write(tree, &mut string);
+    return string;
+}
+
+/// Write a tree into the provided sink.
+pub fn write<T>(tree: &T, output: &mut fmt::Write) -> fmt::Result
+    where T: DisplayTreeNode + TreeNode
+{
+    write_with_prefix(tree, output, &|node| format!("{}", DisplayProxy { value: node }), "")
+}
+
+/// Format a tree into a string, formatting nodes in a specified way.
+pub fn format_with<T>(tree: &T, format: &Fn(&T) -> String) -> String
+    where T: TreeNode
+{
+    let mut string = String::new();
+    let _ = write_with(tree, &mut string, format);
+    return string;
+}
+
+/// Write a tree into the provided sink, formatting nodes in a specified way.
+pub fn write_with<T>(tree: &T, output: &mut fmt::Write, format: &Fn(&T) -> String)
+    -> fmt::Result
+    where T: TreeNode
+{
+    write_with_prefix(tree, output, format, "")
+}
+
+/// A wrapper for `Display` trait.
+///
+/// We *do want* to provide the user with access to `fmt::Formatter` in `DisplayTreeNode` which
+/// enables formatting code reuse. However, Rust does not allow custom formatting traits or
+/// multiple implementations of Display for a single type. Thus we introduce this proxy type
+/// that wraps a reference to `DisplayTreeNode` and provides an implementation of `Display` trait
+/// so that we can use the `{}` format string to output our format.
+struct DisplayProxy<'a, T> where T: 'a + DisplayTreeNode { value: &'a T }
+
+impl<'a, T> fmt::Display for DisplayProxy<'a, T> where T: DisplayTreeNode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.value.fmt(f)
+    }
+}
+
+/// Write a given tree into the provided writer while formatting nodes using the given formatter
+/// and prefixing each line with a given prefix.
+fn write_with_prefix<T>(root: &T, output: &mut fmt::Write, format: &Fn(&T) -> String, prefix: &str)
+    -> fmt::Result
+    where T: TreeNode
+{
+    let root_str = format(root);
+    let mut line = root_str.lines();
+
+    if let Some(current) = line.next() {
+        try!(output.write_str(current));
+        while let Some(current) = line.next() {
+            try!(output.write_char('\n'));
+            try!(output.write_str(prefix));
+            try!(output.write_str(current));
+        }
+    }
+
+    let before_next = format!("\n{}|- ", prefix);
+    let continue_next = format!("{}|  ", prefix);
+    let before_last = format!("\n{}`- ", prefix);
+    let continue_last = format!("{}   ", prefix);
+
+    let children = root.children();
+    let mut iter = children.iter();
+
+    if let Some(mut current) = iter.next() {
+        while let Some(next) = iter.next() {
+            try!(output.write_str(&before_next));
+            try!(write_with_prefix(*current, output, format, &continue_next));
+            current = next;
+        }
+        try!(output.write_str(&before_last));
+        try!(write_with_prefix(*current, output, format, &continue_last));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fmt;
+    use utils::tree::TreeNode;
+
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Example tree implementation
+
+    struct Tree<T> {
+        value: T,
+        children: Vec<Tree<T>>,
+    }
+
+    impl<T> DisplayTreeNode for Tree<T> where T: fmt::Display {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "{}", self.value)
+        }
+    }
+
+    impl<T> TreeNode for Tree<T> {
+        fn children<'a>(&'a self) -> Vec<&'a Self> {
+            self.children.iter().collect()
+        }
+    }
+
+    impl<T> Tree<T> {
+        fn new(value: T, children: Vec<Tree<T>>) -> Tree<T> {
+            Tree { value: value, children: children }
+        }
+    }
+
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Simple formatting
+
+    #[test]
+    fn only_root_element() {
+        let tree = Tree::new(1, vec![]);
+        let expected = "1";
+
+        assert_eq!(expected, format(&tree));
+    }
+
+    #[test]
+    fn sibling_elements() {
+        let tree =
+            Tree::new(1, vec![
+                Tree::new(2, vec![]),
+                Tree::new(3, vec![]),
+                Tree::new(4, vec![]),
+            ]);
+        let expected = "\
+1
+|- 2
+|- 3
+`- 4";
+        assert_eq!(expected, format(&tree));
+    }
+
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // More complex formatting
+
+    #[test]
+    fn nested_elements() {
+        let tree =
+            Tree::new(1, vec![
+                Tree::new(2, vec![
+                    Tree::new(3, vec![]),
+                    Tree::new(4, vec![]),
+                ]),
+                Tree::new(5, vec![
+                    Tree::new(6, vec![
+                        Tree::new(7, vec![]),
+                    ]),
+                ]),
+                Tree::new(8, vec![
+                    Tree::new(9, vec![
+                        Tree::new(10, vec![]),
+                        Tree::new(11, vec![]),
+                    ]),
+                ]),
+                Tree::new(12, vec![
+                    Tree::new(13, vec![]),
+                ]),
+            ]);
+        let expected = "\
+1
+|- 2
+|  |- 3
+|  `- 4
+|- 5
+|  `- 6
+|     `- 7
+|- 8
+|  `- 9
+|     |- 10
+|     `- 11
+`- 12
+   `- 13";
+
+        assert_eq!(expected, format(&tree));
+    }
+
+    #[test]
+    fn multiline_nodes() {
+        let tree =
+            Tree::new("Node\na", vec![
+                Tree::new("Node\nb\nb\n\nb", vec![]),
+                Tree::new("Node\nc", vec![
+                    Tree::new("Node\r\nd", vec![]),
+                ]),
+                Tree::new("Node\ne", vec![]),
+            ]);
+        let expected = "\
+Node
+a
+|- Node
+|  b
+|  b
+|  \n\
+|  b
+|- Node
+|  c
+|  `- Node
+|     d
+`- Node
+   e";
+
+        assert_eq!(expected, format(&tree));
+    }
+
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Ad-hoc formatting function
+
+    #[test]
+    fn formatting_function() {
+        let tree =
+            Tree::new(1, vec![
+                Tree::new(2, vec![]),
+                Tree::new(3, vec![])
+            ]);
+        let expected = "\
+<1>
+|- <2>
+`- <3>";
+
+        assert_eq!(expected, format_with(&tree, &|node| format!("<{}>", node.value)));
+    }
+}

--- a/src/libsyntax/tests/utils/stubs.rs
+++ b/src/libsyntax/tests/utils/stubs.rs
@@ -1,0 +1,36 @@
+// Copyright (c) 2016, ilammy
+//
+// Licensed under MIT license (see LICENSE file in the root directory).
+// This file may be copied, distributed, and modified only in accordance
+// with the terms specified by this license.
+
+//! Stub interface implementations.
+
+use std::rc::Rc;
+use std::cell::RefCell;
+
+use syntax::diagnostics::{Reporter, Span, Severity};
+
+/// A simple Reporter collecting diagnostics.
+pub struct SinkReporter {
+    /// Reporte diagnostics are collected into this vector.
+    pub diagnostics: Rc<RefCell<Vec<(Severity, Span)>>>,
+}
+
+impl Reporter for SinkReporter {
+    fn report(&mut self, severity: Severity, _: &str, loc: Option<Span>) {
+        let mut diagnostics = self.diagnostics.borrow_mut();
+
+        // Scanner diagnostics always come with a location.
+        diagnostics.push((severity, loc.unwrap()));
+    }
+}
+
+impl SinkReporter {
+    /// Make a new reporter that will push all diagnostics into the given vector.
+    pub fn new(diagnostics: Rc<RefCell<Vec<(Severity, Span)>>>) -> SinkReporter {
+        SinkReporter {
+            diagnostics: diagnostics,
+        }
+    }
+}

--- a/src/libsyntax/tests/utils/tree.rs
+++ b/src/libsyntax/tests/utils/tree.rs
@@ -4,11 +4,10 @@
 // This file may be copied, distributed, and modified only in accordance
 // with the terms specified by this license.
 
-//! Test utilities.
-//!
-//! Here we gather miscellaneous utility code that is used throughout our test harness.
+//! Tree utilities.
 
-pub mod diff;
-pub mod iter;
-pub mod stubs;
-pub mod tree;
+/// Trait of tree nodes.
+pub trait TreeNode {
+    /// Returns references to child nodes of this node.
+    fn children<'a>(&'a self) -> Vec<&'a Self>;
+}

--- a/src/libsyntax/tokens.rs
+++ b/src/libsyntax/tokens.rs
@@ -61,6 +61,9 @@ pub enum Token {
     /// An explicit symbol.
     ExplicitSymbol(Atom),
 
+    /// A keyword.
+    Keyword(Keyword),
+
     /// Marker token denoting invalid character sequences.
     Unrecognized,
 }
@@ -95,4 +98,14 @@ pub enum Lit {
 
     /// A raw string of characters.
     RawString(Atom),
+}
+
+/// Literal keyword.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Keyword {
+    /// `library`.
+    Library,
+
+    /// `module`.
+    Module,
 }

--- a/src/libsyntax/tokens.rs
+++ b/src/libsyntax/tokens.rs
@@ -69,7 +69,7 @@ pub enum Token {
 }
 
 /// Delimiter type.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Delimiter {
     /// Parentheses `( )`.
     Paren,


### PR DESCRIPTION
Yeah. This adds the parser and some supporting code.
- Updates, renames, and cleanups in test utilities
- Improved diff support (for sequences and trees)
- New utilities for pretty-printing and diagnostic reporting
- Scanning `module` and `library` keywords
- Parsing `module` and `library` expressions

There is no associated issue with this yet. (I don't have any clear vision of the grammar.)
